### PR TITLE
Add automation for upstream Kubernetes e2e tests

### DIFF
--- a/k8s-e2e-tests/Dockerfile
+++ b/k8s-e2e-tests/Dockerfile
@@ -1,0 +1,19 @@
+FROM opensuse:42.1
+
+MAINTAINER Docker Team <docker-devel@suse.de>
+
+RUN zypper ar -fG http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update:/Products:/CASP10/standard CASP10 && zypper --gpg-auto-import-keys ref
+
+RUN zypper -n install go
+
+RUN zypper -n install etcdctl \
+                      kubernetes-client \
+                      kubernetes-extra
+
+RUN zypper clean -a
+
+WORKDIR /root
+
+COPY    entrypoint.sh   /root/
+
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/k8s-e2e-tests/README.md
+++ b/k8s-e2e-tests/README.md
@@ -1,0 +1,50 @@
+# Kubernetes upstream conformance e2e tests for CaaSP cluster
+
+This is automation for Kubernetes upstream end-to-end tests for CaaSP cluster
+
+## Overview
+
+To run upstream conformance Kubernetes tests script has to build first, Docker openSUSE based image with required packages. When Docker image will be ready, it starts Kubernetes e2e conformance tests. Results from e2e tests will be stored into log file 
+
+`/root/e2e-tests-$(date +%F-%H%M%S).log`.
+
+## Usage
+
+### Requirements
+
+In order to run the Kubernetes conformance e2e tests, the CaaSP cluster has to be installed first. After this we have to extract client connection data e.g. kubeconfig, kube-apiserver url and client certificates.
+
+#### Images used by the Kubernetes e2e tests
+
+During running end-to-end tests, Kubernetes try to pull images from Google's registry.
+
+#### Main options
+
+You can either provide your own `kubeconfig` or point the script to the Kubernetes API server URL (both methods are mutually exclusive)
+
+* `-k|--kubeconfig <FILE>`
+    Provide a "kubeconfig" (when using certificates, they should be
+    specified as `ca.crt`, `admin.crt` or `admin.key`, with dir name
+    /root/.kube/<CERT_FILE_NAME>)
+* `-u|--url <URL>`
+    Kubernetes API server URL (ie, `https://myserver.suse.de:6443`)
+
+#### Certificates
+
+You will have to provide certificates when using a API server that listens at a SSL port.
+
+* `--ca-crt <FILE>`:
+    The `ca.crt` file (this option is required)
+* `--admin-crt <FILE>`:
+    The `admin.crt` file (this option is required)
+* `--admin-key <FILE>`:
+    The `admin.key` file (this option is required)
+
+#### Examples
+
+```
+./e2e-tests --url https://10.162.168.207:6443 \
+    --ca-crt ca.crt \
+    --admin-crt admin.crt \
+    --admin-key admin.key
+```

--- a/k8s-e2e-tests/e2e-tests
+++ b/k8s-e2e-tests/e2e-tests
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+# options
+IMAGE_NAME=k8s-e2e-tests
+CURR_DIR=$( pwd )
+DOCKER_RUN_ARGS="-ti"
+
+USAGE=$(cat <<USAGE
+Usage:
+
+  * providing a "kubeconfig"
+
+    -k|--kubeconfig <FILE>   kubeconfig file
+
+  * providing API server access details
+
+    -u|--url <URL>           kubernetes API server URL
+
+Certificates:
+
+    --ca-crt <FILE>          the ca.crt file
+    --admin-crt <FILE>       the admin.crt file
+    --admin-key <FILE>       the admin.key file
+
+USAGE
+)
+
+
+# logging
+log()   { (>&2 echo ">>> [e2e-tests] $@") ; }
+warn()  { log "WARNING: $@" ; }
+error() { log "ERROR: $@" ; exit 1 ; }
+abort() { log "FATAL: $@" ; exit 1 ; }
+
+# images
+
+image_cleanup() {
+  [ -n "$IMAGE_NAME" ] || abort "no IMAGE_NAME provided"
+
+  log "Stop container $IMAGE_NAME"
+  docker stop -t 5 "$IMAGE_NAME" 2>/dev/null || true
+  log "Remove container $IMAGE_NAME"
+  docker rm "$IMAGE_NAME" 2>/dev/null || true
+  log "Clean up image $IMAGE_NAME"
+  docker rmi "$IMAGE_NAME" 2>/dev/null || true
+}
+
+image_build() {
+  [ -n "$IMAGE_NAME" ] || abort "no IMAGE_NAME provided"
+
+  log "Building image"
+  docker build -t "$IMAGE_NAME" .
+  res=$?
+  return $res
+}
+
+image_run() {
+  [ -n "$IMAGE_NAME" ] || abort "no IMAGE_NAME provided"
+
+  log "Running the container..."
+  docker run --net=host \
+      --name "$IMAGE_NAME" \
+    $DOCKER_RUN_ARGS \
+    $IMAGE_NAME
+}
+
+check_file() {
+    if [ ! -f $1 ]; then
+        error "File $1 doesn't exist!"
+    fi
+}
+
+# options
+
+while [[ $# > 0 ]] ; do
+  case $1 in
+    -u|--url)
+      DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS -e KUBE_API_URL=$2"
+      URL=1
+      shift
+      ;;
+    --ca-crt)
+      f="$(realpath $2)"
+      check_file $f
+      DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS -v $f:/root/.kube/ca.crt"
+      CA_CRT=1
+      shift
+      ;;
+    --admin-crt)
+      f="$(realpath $2)"
+      check_file $f
+      DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS -v $f:/root/.kube/admin.crt"
+      ADM_CRT=1
+      shift
+      ;;
+    --admin-key)
+      f="$(realpath $2)"
+      check_file $f
+      DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS -v $f:/root/.kube/admin.key"
+      ADM_KEY=1
+      shift
+      ;;
+    -k|--kubeconfig)
+      f="$(realpath $2)"
+      check_file $f
+      DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS -e KUBECONFIG=$2 -v $f:/root/.kube/config"
+      K8S_CFG=1
+      shift
+      ;;
+    -h|--help)
+      echo "$USAGE"
+      exit 0
+      ;;
+  esac
+  shift
+done
+
+if [ -z $URL ] && [ -z $K8S_CFG ]; then
+    error "Option -u|--url or -k|--kubeconfig is required"
+fi
+[ -z $CA_CRT ]  && error "Option --ca-crt is required"
+[ -z $ADM_CRT ] && error "Option --admin-crt is required"
+[ -z $ADM_KEY ] && error "Option --admin-key is required"
+
+# main
+
+image_cleanup || abort "could not cleanup"
+image_build   || abort "could not build image"
+image_run     || abort "'docker run' failed"
+
+log "Done."

--- a/k8s-e2e-tests/entrypoint.sh
+++ b/k8s-e2e-tests/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+kubeconfig_certs_paths() {
+    sed -i '
+        /certificate-authority:/ s/.*/certificate-authority: \/root\/.kube\/ca.crt/
+        /client-certificate:/ s/.*/client-certificate: \/root\/.kube\/admin.crt/
+        /client-key:/ s/.*/client-key: \/root\/.kube\/admin.key/
+    ' /root/.kube/config
+
+}
+
+kubeconfig_gen() {
+    mkdir -p /root/.kube
+    cat <<EOF > /root/.kube/config
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /root/.kube/ca.crt
+    server: $KUBE_API_URL
+  name: default-cluster
+contexts:
+- context:
+    cluster: default-cluster
+    user: default-admin
+  name: default-system
+current-context: default-system
+kind: Config
+preferences: {}
+users:
+- name: default-admin
+  user:
+    client-certificate: /root/.kube/admin.crt
+    client-key: /root/.kube/admin.key
+EOF
+}
+
+deploy_kube_dns() {
+    kubectl apply -f https://raw.githubusercontent.com/SUSE/caasp-services/master/contrib/addons/kubedns/dns.yaml
+}
+
+run_tests() {
+    export KUBECONFIG=/root/.kube/config
+    export KUBECTL_PATH=/usr/bin/kubectl
+    export PATH=$KUBE_ROOT/platforms/linux/amd64:$PATH
+    export KUBE_ROOT=/usr/src/kubernetes
+    export KUBERNETES_CONFORMANCE_TEST=y
+    export KUBE_TEST_AGRS="\
+        -v=5 \
+        --alsologtostderr \
+        --ginkgo.progress \
+        --e2e-verify-service-account=false \
+        --clean-start=true \
+        --dump-logs-on-failure \
+        --delete-namespace=true \
+        --ginkgo.trace=true" 
+    
+    cd $KUBE_ROOT
+    go run hack/e2e.go -v --test --test_args="$KUBE_TEST_AGRS --ginkgo.focus=\[Conformance\]" 2>&1 | tee /root/e2e-tests-$(date +%F-%H%M%S).log
+}
+
+# main
+if [ -n "$KUBE_API_URL" ] ; then
+    kubeconfig_gen
+elif [ -n "$KUBECONFIG" ] ; then
+    kubeconfig_certs_paths
+else
+    abort "we need either a --kubeconfig or a --url"
+fi
+
+deploy_kube_dns
+
+run_tests


### PR DESCRIPTION
Automation for upstream Kubernetes end-to-end tests for CaaSP cluster.
To run tests script has to build first, Docker openSUSE based image
with required packages. When Docker image will be ready, it starts
Kubernetes e2e conformance tests and store logs into file.

Please check README.md file for more information.