### PR TITLE
rescue in case button is not visible at all yet

### DIFF
--- a/velum-bootstrap/spec/features/bootstrap_cluster.rb
+++ b/velum-bootstrap/spec/features/bootstrap_cluster.rb
@@ -46,7 +46,7 @@ feature "Boostrap cluster" do
 
     puts ">>> Wait for accept-all button to be enabled"
     wait_for(timeout: 20, interval: 5) do
-      !find_button("accept-all").disabled?
+      !find_button("accept-all").disabled? rescue false
     end
     puts "<<< accept-all button enabled"
 


### PR DESCRIPTION
capybara throws an exception if it can't find an element right away
and this leads to a failed test immediately

Signed-off-by: Maximilian Meister <mmeister@suse.de>