### PR TITLE
Make the 'docker run' flags configurable

### DIFF
--- a/k8s-e2e-tests/e2e-tests
+++ b/k8s-e2e-tests/e2e-tests
@@ -2,8 +2,7 @@
 
 # options
 IMAGE_NAME=k8s-e2e-tests
-CURR_DIR=$( pwd )
-DOCKER_RUN_ARGS="-ti"
+DOCKER_RUN_ARGS=${DOCKER_RUN_ARGS:-"-ti"}
 
 USAGE=$(cat <<USAGE
 Usage:


### PR DESCRIPTION
In some cases, ,we cannot use `-ti` when doing `docker run` (in particular, in CI)