### PR TITLE
Disable colour in k8s-e2e-tests

### DIFF
--- a/k8s-e2e-tests/entrypoint.sh
+++ b/k8s-e2e-tests/entrypoint.sh
@@ -54,7 +54,8 @@ run_tests() {
         --clean-start=true \
         --dump-logs-on-failure \
         --delete-namespace=true \
-        --ginkgo.trace=true"
+        --ginkgo.trace=true \
+        --ginkgo.noColor=y"
 
     cd $KUBE_ROOT
 


### PR DESCRIPTION
Colour output makes CI really hard to read