### PR TITLE
Increase velum timeouts

### DIFF
--- a/velum-bootstrap/spec/features/bootstrap_cluster.rb
+++ b/velum-bootstrap/spec/features/bootstrap_cluster.rb
@@ -38,14 +38,14 @@ feature "Boostrap cluster" do
     visit "/setup/discovery"
 
     puts ">>> Wait until all minions are pending to be accepted"
-    wait_for(timeout: 120, interval: 5) do
+    wait_for(timeout: 600, interval: 5) do
       minions = YAML.load(salt_master_container.command(list_salt_keys_command)[:stdout])
       minions["minions_pre"].length == node_number
     end
     puts "<<< All minions are pending to be accepted"
 
     puts ">>> Wait for accept-all button to be enabled"
-    wait_for(timeout: 120, interval: 5) do
+    wait_for(timeout: 600, interval: 5) do
       !find_button("accept-all").disabled? rescue false
     end
     puts "<<< accept-all button enabled"
@@ -54,7 +54,7 @@ feature "Boostrap cluster" do
     click_button("accept-all")
 
     puts ">>> Wait until Minion keys are accepted by salt"
-    wait_for(timeout: 120, interval: 5) do
+    wait_for(timeout: 600, interval: 5) do
       raw = salt_master_container.command(list_salt_keys_command)[:stdout]
       minions = YAML.load raw
       minions["minions_pre"].empty?
@@ -62,14 +62,14 @@ feature "Boostrap cluster" do
     puts "<<< Minion keys accepted by salt"
 
     puts ">>> Wait until Minions are registered in the Velum database"
-    minions_registered = wait_for(timeout: 120, interval: 5) do
+    minions_registered = wait_for(timeout: 600, interval: 5) do
       dashboard_container.command(minion_count_command)[:stdout].to_i == node_number
     end
     expect(minions_registered).to be(true)
     puts "<<< Minions registered in the Velum database"
 
     puts ">>> Waiting until Minions are accepted in Velum"
-    minions_accepted = wait_for(timeout: 120, interval: 10) do
+    minions_accepted = wait_for(timeout: 600, interval: 10) do
       first("h3").text == "#{node_number} nodes found"
     end
     expect(minions_accepted).to be(true)


### PR DESCRIPTION
Since these are hitting in CI, lets make them bigger. The primary purpose
of these timeouts is to prevent the run from stalling forever, rather than
to enforce any kind of perfomance goals. As such, set them to something
much larger to allow for variance in timing.