### PR TITLE
Update velum-bootstrap for multimaster changes

### DIFF
--- a/velum-bootstrap/spec/features/bootstrap_cluster.rb
+++ b/velum-bootstrap/spec/features/bootstrap_cluster.rb
@@ -58,7 +58,7 @@ feature "Boostrap cluster" do
 
     puts ">>> Wait until Minion keys are accepted by salt"
     with_screenshot(name: :accepted_keys) do
-      expect(page).to have_css("input[type='radio']", count: node_number, wait: 600)
+      expect(page).to have_css("input[name='roles[worker][]']", count: node_number, wait: 600)
     end
     puts "<<< Minion keys accepted in Velum"
 
@@ -86,7 +86,7 @@ feature "Boostrap cluster" do
     puts ">>> Selecting master minion"
     with_screenshot(name: :select_master) do
       within("tr", text: master_minion["minionID"]) do
-        find("input[type='radio']").click
+        find("input[name='roles[master][]']").click
       end
     end
     puts "<<< Master minion selected"


### PR DESCRIPTION
This will still only bootstrap with 1 master, however it should
allow the multi-master velum change to pass CI and land.