### PR TITLE
Replace tasks with pipeline variants

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.image-cacher
+++ b/jenkins-pipelines/Jenkinsfile.image-cacher
@@ -1,35 +1,33 @@
 library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
-properties(
-	[
-		[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '31']],
-		[$class: 'DisableConcurrentBuildsJobProperty'],
-		pipelineTriggers([
-			[$class: 'org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger',
-				parameterizedSpecification: 'H/15 * * * *  % CHANNEL=devel\nH/15 * * * *  % CHANNEL=release'
-			]
-		]),
-		parameters([
-			choice(choices: 'devel\nrelease', description: 'What channel should the image be cached from?', name: 'CHANNEL')
-		])
-	]
-)
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([
+        [$class: 'org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger',
+            parameterizedSpecification: 'H/15 * * * *  % CHANNEL=devel\nH/15 * * * *  % CHANNEL=release'
+        ]
+    ]),
+    parameters([
+        choice(choices: 'devel\nrelease', description: 'What channel should the image be cached from?', name: 'CHANNEL')
+    ])
+])
 
 node('leap42.2') {
-	timeout(60){
-		stage('Preparation') {
-			step([$class: 'WsCleanup'])
-		}
+    timeout(60){
+        stage('Preparation') {
+            cleanWs()
+        }
 
-		stage('Retrieve Code') {
-			cloneKubicRepo(gitBase: "https://github.com/kubic-project", branch: env.BRANCH_NAME, credentialsId: "github-token", repo: "automation")
-		}
+        stage('Retrieve Code') {
+            cloneKubicRepo(gitBase: "https://github.com/kubic-project", branch: env.BRANCH_NAME, credentialsId: "github-token", repo: "automation")
+        }
 
-		stage('Fetch Image') {
-			dir('automation/caasp-kvm') {
-				sh(script: "./tools/download_image.py channel://${params.CHANNEL}")
-			}
-		}
-	}
+        stage('Fetch Image') {
+            dir('automation/caasp-kvm') {
+                sh(script: "./tools/download_image.py channel://${params.CHANNEL}")
+            }
+        }
+    }
 }

--- a/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
@@ -1,13 +1,11 @@
 library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
-properties(
-    [
-        [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '31']],
-        [$class: 'DisableConcurrentBuildsJobProperty'],
-        pipelineTriggers([cron('@daily')]),
-    ]
-)
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('@daily')]),
+])
 
 coreKubicProjectPeriodic(minionCount: 3) {
     stage('Run K8S Conformance Tests') {

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly
@@ -1,12 +1,10 @@
 library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
-properties(
-    [
-        [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '31']],
-        [$class: 'DisableConcurrentBuildsJobProperty'],
-        pipelineTriggers([cron('@daily')]),
-    ]
-)
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('@daily')]),
+])
 
 coreKubicProjectPeriodic(minionCount: 3)


### PR DESCRIPTION
Several of the $class statements we used already have pipeline
variants, without the need to construct by hand. Replace these
with the matching pipeline versions.

Additionally, be consistent over the use of tabs v spaces, and
reduce some excessive indentations.