### PR TITLE
velum-bootstrap: spec updated based on multiple master selection

### DIFF
--- a/velum-bootstrap/spec/features/bootstrap_cluster.rb
+++ b/velum-bootstrap/spec/features/bootstrap_cluster.rb
@@ -79,14 +79,14 @@ feature "Boostrap cluster" do
 
     puts ">>> Selecting all minions"
     with_screenshot(name: :select_all_minions) do
-      find(".check-all").click
+      find(".select-nodes-btn").click
     end
     puts "<<< All minions selected"
 
     puts ">>> Selecting master minion"
     with_screenshot(name: :select_master) do
       within("tr", text: master_minion["minionId"] || master_minion["minionID"]) do
-        find("input[name='roles[master][]']").click
+        find(".master-btn").click
       end
     end
     puts "<<< Master minion selected"


### PR DESCRIPTION
I've just updated the selectors to reflect the change on velum for the current specs. No use case was added for the multiple master selection itself. Lemme if know if that's necessary or not.

Depends-On: https://github.com/kubic-project/velum/pull/278