### PR TITLE
WIP: Downloader script cleanup

### DIFF
--- a/caasp-kvm/.gitignore
+++ b/caasp-kvm/.gitignore
@@ -1,5 +1,3 @@
-*.qcow2
 *.tfstate*
-*.tar.xz
 terraform.tfvars
 crash.log

--- a/caasp-kvm/cluster.tf
+++ b/caasp-kvm/cluster.tf
@@ -102,7 +102,7 @@ provider "libvirt" {
 
 resource "null_resource" "local_checkout_of_caasp_image" {
   provisioner "local-exec" {
-    command = "./tools/download_image.py ${var.caasp_img_source_url}"
+    command = "../misc-tools/download_image.py ../downloads kvm ${var.caasp_img_source_url}"
   }
 }
 
@@ -127,7 +127,7 @@ resource "null_resource" "local_create_velum_dirs" {
 # This is the CaaSP kvm image that has been created by IBS
 resource "libvirt_volume" "caasp_img" {
   name   = "${basename(var.caasp_img_source_url)}"
-  source = "${basename(var.caasp_img_source_url)}"
+  source = "../downloads/kvm-${basename(var.caasp_img_source_url)}"
   pool   = "${var.pool}"
 
   depends_on = ["null_resource.local_checkout_of_caasp_image"]

--- a/caasp-kvm/tools/build-velum-image.sh
+++ b/caasp-kvm/tools/build-velum-image.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 function download_velum_development_image() {
   #TODO: ensure the name of the image downloaded is returned. The wrong image name
   # might be returned if multiple tarballs are into the directory
-  $1/download_image.py --docker-image-name sles12-velum-developmen channel://head
-  echo $(realpath sles12-velum-development.*.tar.xz)
+  $1/../../misc-tools/download_image.py --docker-image-name sles12-velum-development $(realpath $1/../../downloads) velum-development channel://devel
+  echo $(realpath $1/../../downloads/sles12-velum-development.*.tar.xz)
 }
 
 # docker load of the velum-development image tarball

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/jenkins-pipelines/Jenkinsfile.image-cacher
+++ b/jenkins-pipelines/Jenkinsfile.image-cacher
@@ -25,8 +25,8 @@ node('leap42.2') {
         }
 
         stage('Fetch Image') {
-            dir('automation/caasp-kvm') {
-                sh(script: "./tools/download_image.py channel://${params.CHANNEL}")
+            dir('automation') {
+                sh(script: "./misc-tools/download_image.py downloads/ kvm channel://${params.CHANNEL}")
             }
         }
     }


### PR DESCRIPTION
* Move to misc-tools
* Download files to a download folder
* Put symlinks into that same download folder
* Disambiguate symlinks based on type  - we download both the velum container and the qcow2 from devel, this worked by fluke previously as we have the devel repo listed twice - once as devel, once as head.