### PR TITLE
Heat: Allow traffic to port 80

### DIFF
--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -121,6 +121,9 @@ resources:
     properties:
       rules:
         - protocol: tcp
+          port_range_min: 80
+          port_range_max: 80
+        - protocol: tcp
           port_range_min: 443
           port_range_max: 443
         - protocol: tcp


### PR DESCRIPTION
There is a redirect in place from 80->443, allow access to this
when building the stack with Heat