### PR TITLE
Add specs to update CaaSP

### DIFF
--- a/velum-bootstrap/spec/features/03-upgrade-admin.rb
+++ b/velum-bootstrap/spec/features/03-upgrade-admin.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+require 'yaml'
+
+feature "Upgrade Admin Node" do
+
+  let(:node_number) { environment["minions"].count { |element| element["role"] != "admin" } }
+  let(:hostnames) { environment["minions"].map { |m| m["fqdn"] if m["role"] != "admin" }.compact }
+
+  before(:each) do
+    login
+  end
+
+  # Using append after in place of after, as recommended by
+  # https://github.com/mattheworiordan/capybara-screenshot#common-problems
+  append_after(:each) do
+    Capybara.reset_sessions!
+  end
+
+  scenario "User clicks update admin node" do
+    visit "/"
+
+    puts ">>> Wait for update-admin-node button to be enabled"
+    with_screenshot(name: :update_admin_node_button_enabled) do
+      expect(page).to have_selector("a.update-admin-btn", wait: 400)
+    end
+    puts "<<< update-admin-node button enabled"
+
+    puts ">>> Click to update admin node"
+    with_screenshot(name: :update_admin_node_button_click) do
+      find('a.update-admin-btn').click
+    end
+    puts ">>> update admin node clicked"
+
+    puts ">>> Wait for reboot-admin-node button to be enabled"
+    with_screenshot(name: :reboot_admin_node_button_enabled) do
+      expect(page).to have_selector("button.reboot-update-btn", wait: 15)
+    end
+    puts "<<< reboot-admin-node button enabled"
+
+    puts ">>> Click to reboot admin node"
+    with_screenshot(name: :reboot_admin_node_button_click) do
+      find('button.reboot-update-btn').click
+    end
+    puts ">>> reboot admin node clicked"
+
+    # Allow 30 seconds for Velum to be shutdown before proceeding
+    sleep 30
+
+    puts ">>> Wait for Velum to recover"
+    1.upto(600) do |n|
+      begin
+        visit "/"
+        expect(page.status_code).to be(200)
+        break
+      rescue Exception => e
+        if n == 600
+          raise e
+        else
+          puts "... still waiting for velum to recover"
+          sleep 1
+        end
+      end
+    end
+    puts "<<< Velum has recovered"
+  end
+end

--- a/velum-bootstrap/spec/features/04-upgrade-minions.rb
+++ b/velum-bootstrap/spec/features/04-upgrade-minions.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require 'yaml'
+
+feature "update Admin Node" do
+
+  let(:node_number) { environment["minions"].count { |element| element["role"] != "admin" } }
+  let(:hostnames) { environment["minions"].map { |m| m["fqdn"] if m["role"] != "admin" }.compact }
+
+  before(:each) do
+    login
+  end
+
+  # Using append after in place of after, as recommended by
+  # https://github.com/mattheworiordan/capybara-screenshot#common-problems
+  append_after(:each) do
+    Capybara.reset_sessions!
+  end
+
+  scenario "User clicks update all nodes" do
+    visit "/"
+
+    puts ">>> Wait for update-all-nodes button to be enabled"
+    with_screenshot(name: :update_all_nodes_button_enabled) do
+      expect(page).to have_link(id: "update-all-nodes", wait: 120)
+    end
+    puts "<<< update-all-nodes button enabled"
+
+    puts ">>> Wait until all minions are pending an update"
+    with_screenshot(name: :pending_update) do
+      expect(page).to have_text("Update Available", count: node_number, wait: 120)
+    end
+    puts "<<< All minions are pending an update"
+
+    puts ">>> Click to update all nodes"
+    with_screenshot(name: :update_all_nodes_button_click) do
+      find('#update-all-nodes').click
+    end
+    puts ">>> update all nodes clicked"
+
+    # Allow 10 seconds for Velum to re-render nodes with spinners
+    sleep 10
+
+    puts ">>> Wait until update is complete"
+    with_screenshot(name: :update_complete) do
+      within(".nodes-container") do
+        expect(page).to have_css(".fa-check-circle-o", count: node_number, wait: 1800)
+      end
+    end
+    puts "<<< Update completed"
+  end
+end

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -8,6 +8,8 @@ HAS_INTERACTION=false
 RUN_SETUP=false
 RUN_CONFIGURE=false
 RUN_BOOTSTRAP=false
+RUN_UPDATE_ADMIN=false
+RUN_UPDATE_MINIONS=false
 
 USAGE=$(cat <<USAGE
 Usage:
@@ -21,11 +23,20 @@ Usage:
     -c|--configure                   Configure Velum
     -b|--bootstrap                   Bootstrap
 
+  * Updating a cluster
+
+    -a|--update-admin                Update admin node
+    -m|--update-minions              Update masters and workers
+
   * Examples:
 
   Bootstrap a cluster
 
   $0 --configure --bootstrap
+
+  Update a cluster
+
+  $0 --update-admin --update-minions
 
 USAGE
 )
@@ -50,6 +61,16 @@ while [[ $# > 0 ]] ; do
       ;;
     -b|--bootstrap)
       RUN_BOOTSTRAP=true
+      HAS_INTERACTION=true
+      HAS_ACTION=true
+      ;;
+    -a|--update-admin)
+      RUN_UPDATE_ADMIN=true
+      HAS_INTERACTION=true
+      HAS_ACTION=true
+      ;;
+    -m|--update-minions)
+      RUN_UPDATE_MINIONS=true
       HAS_INTERACTION=true
       HAS_ACTION=true
       ;;
@@ -84,6 +105,14 @@ interact() {
 
   if [ "$RUN_BOOTSTRAP" = true ]; then
     args="$args spec/**/02-*"
+  fi
+
+  if [ "$RUN_UPDATE_ADMIN" = true ]; then
+    args="$args spec/**/03-*"
+  fi
+
+  if [ "$RUN_UPDATE_MINIONS" = true ]; then
+    args="$args spec/**/04-*"
   fi
 
   VERBOSE=true bundle exec rspec $args


### PR DESCRIPTION
Add two new specs to handle upgrading of CaaSP, one for the admin node, and one
for the masters and workers.

Depends-On: https://github.com/kubic-project/jenkins-library/pull/76