### PR TITLE
Allow port 6444 through secgroups

### DIFF
--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -139,7 +139,7 @@ resources:
           port_range_max: 2380
         - protocol: tcp
           port_range_min: 6443
-          port_range_max: 6443
+          port_range_max: 6444
         - protocol: udp
           port_range_min: 8285
           port_range_max: 8285

--- a/caasp-openstack-terraform/caasp-cluster.tf
+++ b/caasp-openstack-terraform/caasp-cluster.tf
@@ -97,7 +97,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
 
   rule {
     from_port   = 6443
-    to_port     = 6443
+    to_port     = 6444
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }


### PR DESCRIPTION
This is used for worker -> master API access since the HAProxy
change landed.