### PR TITLE
KVM: Force VMs MTUs down to 1400

### DIFF
--- a/caasp-kvm/cloud-init/admin.cfg
+++ b/caasp-kvm/cloud-init/admin.cfg
@@ -36,6 +36,7 @@ bootcmd:
   - mkdir -p /var/lib/overlay/velum-upper
   - mkdir -p /var/lib/overlay/velum-work
   - mkdir -p /var/lib/misc/velum-resources
+  - ip link set dev eth0 mtu 1400
 
 runcmd:
   - /usr/bin/systemctl enable --now ntpd

--- a/caasp-kvm/cloud-init/master.cfg.tpl
+++ b/caasp-kvm/cloud-init/master.cfg.tpl
@@ -25,4 +25,7 @@ suse_caasp:
   role: cluster
   admin_node: ${admin_ip}
 
+bootcmd:
+  - ip link set dev eth0 mtu 1400
+
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/caasp-kvm/cloud-init/worker.cfg.tpl
+++ b/caasp-kvm/cloud-init/worker.cfg.tpl
@@ -25,4 +25,7 @@ suse_caasp:
   role: cluster
   admin_node: ${admin_ip}
 
+bootcmd:
+  - ip link set dev eth0 mtu 1400
+
 final_message: "The system is finally up, after $UPTIME seconds"


### PR DESCRIPTION
In some envs, we're forced to drop the MTU down. Since we can't control this
with terraform's libvirt plugin, we can add it as an early run command with
cloud init. As this is a dev environment tool, a 1400 MTU should be harmless