### PR TITLE
Add HTTP proxy support for dev tools

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -17,6 +17,7 @@ RUN_DESTROY=false
 
 MASTERS=1
 WORKERS=2
+PROXY=${CAASP_HTTP_PROXY:-}
 PARALLELISM=1
 
 # READ THIS BEFORE ADDING ANYTHING HERE.
@@ -55,6 +56,7 @@ Usage:
   * Common options
 
     -p|--parallelism         Set terraform parallelism
+    -P|--proxy               Set HTTP Proxy (Default: CAASP_HTTP_PROXY)
 
   * Examples:
 
@@ -106,8 +108,12 @@ while [[ $# > 0 ]] ; do
       RUN_TESTINFRA=true
       HAS_ACTION=true
       ;;
-    -p|parallelism)
+    -p|--parallelism)
       PARALLELISM="$2"
+      shift
+      ;;
+    -P|--proxy)
+      PROXY="$2"
       shift
       ;;
     -h|--help)
@@ -139,7 +145,7 @@ setup() {
 build() {
   pushd caasp-kvm
   log "Starting CaaSP KVM Environment"
-  ./caasp-kvm --build -m $MASTERS -w $WORKERS -parallelism=$PARALLELISM
+  ./caasp-kvm --build -m $MASTERS -w $WORKERS --parallelism=$PARALLELISM --proxy "${PROXY}"
   popd
 }
 
@@ -165,7 +171,7 @@ destroy() {
   pushd caasp-kvm
 
   log "Destroy CaaSP KVM Environment"
-  ./caasp-kvm --destroy
+  ./caasp-kvm --destroy --parallelism=$PARALLELISM --proxy "${PROXY}"
   popd
 }
 

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -10,6 +10,7 @@ RUN_DESTROY=false
 MASTERS=1
 WORKERS=2
 IMAGE=channel://devel
+PROXY=${CAASP_HTTP_PROXY:-}
 PARALLELISM=1
 
 USAGE=$(cat <<USAGE
@@ -29,7 +30,7 @@ Usage:
   * Common options
 
     -p|--parallelism                 Set terraform parallelism
-
+    -P|--proxy                       Set HTTP Proxy (Default: CAASP_HTTP_PROXY)
   * Examples:
 
   Build a 1 master, 2 worker cluster
@@ -72,8 +73,12 @@ while [[ $# > 0 ]] ; do
       IMAGE="$2"
       shift
       ;;
-    -p|parallelism)
+    -p|--parallelism)
       PARALLELISM="$2"
+      shift
+      ;;
+    -P|--proxy)
+      PROXY="$2"
       shift
       ;;
     -d|--destroy)
@@ -93,11 +98,11 @@ build() {
   log "CaaS Platform Building"
 
   log "Downloading CaaSP KVM Image"
-  ../misc-tools/download_image.py --type kvm $IMAGE
+  ../misc-tools/download_image.py --proxy "${PROXY}" --type kvm $IMAGE
 
   log "Building Velum Development Image"
   local velum=$(realpath ../../velum)
-  ./tools/build-velum-image.sh $velum
+  ./tools/build-velum-image.sh $velum "${PROXY}"
 
   log "Creating Velum Directories"
   mkdir -p $velum/tmp $velum/log $velum/vendor/bundle

--- a/caasp-kvm/tools/build-velum-image.sh
+++ b/caasp-kvm/tools/build-velum-image.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 function download_velum_development_image() {
   #TODO: ensure the name of the image downloaded is returned. The wrong image name
   # might be returned if multiple tarballs are into the directory
-  echo $($1/download_image.py --type docker --image-name sles12-velum-development channel://devel | grep "File on Disk" | cut -d ":" -f2)
+  echo $($1/download_image.py  --proxy "${2:-}" --type docker --image-name sles12-velum-development channel://devel | grep "File on Disk" | cut -d ":" -f2)
 }
 
 # docker load of the velum-development image tarball

--- a/jenkins-pipelines/Jenkinsfile.image-cacher
+++ b/jenkins-pipelines/Jenkinsfile.image-cacher
@@ -26,7 +26,7 @@ node('leap42.3') {
 
         stage('Fetch Image') {
             dir('automation/misc-tools') {
-                sh(script: "./download_image.py --type kvm channel://${params.CHANNEL}")
+                sh(script: "./download_image.py --proxy ${env.http_proxy} --type kvm channel://${params.CHANNEL}")
             }
         }
     }


### PR DESCRIPTION
Setting CAASP_HTTP_PROXY in ~/.bashrc or similar should mean the dev tools will use the proxy to download anything it needs to fetch from NUE etc

Depends-On: https://github.com/kubic-project/jenkins-library/pull/82