### PR TITLE
Heat: Fix generation of keypair/network names

### DIFF
--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -75,14 +75,20 @@ resources:
     type: OS::Nova::KeyPair
     properties:
       name:
-         list_join: ['-', [{ get_param: 'OS::stack_name' }, 'caasp-keypair']]
+        str_replace:
+          template: {list_join: ['-', [{get_param: 'OS::stack_name'}, 'caasp-keypair']]}
+          params:
+            ".": "-"
       public_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf insecure-key
 
   internal_network:
     type: OS::Neutron::Net
     properties:
       name:
-         list_join: ['-', [{ get_param: 'OS::stack_name' }, 'caasp-int-net']]
+        str_replace:
+          template: {list_join: ['-', [{get_param: 'OS::stack_name'}, 'caasp-int-net']]}
+          params:
+            ".": "-"
 
   internal_subnet:
     type: OS::Neutron::Subnet


### PR DESCRIPTION
For some CI runs (like release-1.0 branch builds), the stack name would end up
containing a period, which is disallowed some in OpenStack resource names. We
fix this by replacing any periods with hyphens.