### PR TITLE
Update downloader for new image location

### DIFF
--- a/misc-tools/download_image.py
+++ b/misc-tools/download_image.py
@@ -179,7 +179,7 @@ def get_channel_url(args):
 
     base_url = URL_BASE[channel]
     if args.type == "docker":
-        base_url += 'images_container_derived'
+        base_url += 'images_container_base'
     elif args.type in ["kvm", "openstack"]:
         base_url += 'images'
     elif args.type == "iso":


### PR DESCRIPTION
Docker images now build in the images_container_base rather
than images_container_derived repos, update the downloader
to match.