### PR TITLE
Make environment destruction optional

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
@@ -7,12 +7,14 @@ properties([
     pipelineTriggers([cron('@daily')]),
     parameters([
         string(name: 'MASTER_COUNT', defaultValue: '1', description: 'Number of Master Nodes'),
-        string(name: 'WORKER_COUNT', defaultValue: '3', description: 'Number of Worker Nodes')
+        string(name: 'WORKER_COUNT', defaultValue: '3', description: 'Number of Worker Nodes'),
+        booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?')
     ])
 ])
 
 coreKubicProjectPeriodic(
     environmentType: 'bare-metal',
+    environmentDestroy: env.ENVIRONMENT_DESTROY,
     masterCount: env.MASTER_COUNT.toInteger(),
     workerCount: env.WORKER_COUNT.toInteger()
 )

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
@@ -11,7 +11,8 @@ properties([
         string(name: 'WORKER_COUNT', defaultValue: '25', description: 'Number of Worker Nodes'),
         string(name: 'ADMIN_FLAVOR', defaultValue: 'm1.xxlarge', description: 'Flavor for Admin Node'),
         string(name: 'MASTER_FLAVOR', defaultValue: 'm1.xxlarge', description: 'Flavor for Master Nodes'),
-        string(name: 'WORKER_FLAVOR', defaultValue: 'm1.large', description: 'Flavor for Worker Nodes')
+        string(name: 'WORKER_FLAVOR', defaultValue: 'm1.large', description: 'Flavor for Worker Nodes'),
+        booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?')
     ])
 ])
 
@@ -24,6 +25,7 @@ openstackTypeOptions.workerFlavor = env.WORKER_FLAVOR
 coreKubicProjectPeriodic(
     environmentType: 'openstack',
     environmentTypeOptions: openstackTypeOptions,
+    environmentDestroy: env.ENVIRONMENT_DESTROY,
     masterCount: env.MASTER_COUNT.toInteger(),
     workerCount: env.WORKER_COUNT.toInteger()
 )


### PR DESCRIPTION
This is useful for when you use Jenkins to build an env, but want
to keep it around for debugging.