### PR TITLE
Allow accessing masters on the K8S NodePort range, Allow access to admin on 389

### DIFF
--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -149,6 +149,12 @@ resources:
         - protocol: udp
           port_range_min: 8285
           port_range_max: 8285
+        - protocol: tcp
+          port_range_min: 30000
+          port_range_max: 32768
+        - protocol: udp
+          port_range_min: 30000
+          port_range_max: 32768
 
   secgroup_worker:
     type: OS::Neutron::SecurityGroup
@@ -172,12 +178,12 @@ resources:
         - protocol: tcp
           port_range_min: 10250
           port_range_max: 10250
-        - protocol: tcp
-          port_range_min: 30000
-          port_range_max: 32768
         - protocol: udp
           port_range_min: 8285
           port_range_max: 8285
+        - protocol: tcp
+          port_range_min: 30000
+          port_range_max: 32768
         - protocol: udp
           port_range_min: 30000
           port_range_max: 32768

--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -135,6 +135,9 @@ resources:
         - protocol: tcp
           port_range_min: 4505
           port_range_max: 4506
+        - protocol: tcp
+          port_range_min: 389
+          port_range_max: 389
 
   secgroup_master:
     type: OS::Neutron::SecurityGroup

--- a/caasp-openstack-terraform/caasp-cluster.tf
+++ b/caasp-openstack-terraform/caasp-cluster.tf
@@ -108,6 +108,20 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }
+
+  rule {
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
 }
 
 resource "openstack_compute_secgroup_v2" "secgroup_worker" {
@@ -158,16 +172,16 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
   }
 
   rule {
-    from_port   = 30000
-    to_port     = 32768
-    ip_protocol = "tcp"
+    from_port   = 8285
+    to_port     = 8285
+    ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }
 
   rule {
-    from_port   = 8285
-    to_port     = 8285
-    ip_protocol = "udp"
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }
 

--- a/caasp-openstack-terraform/caasp-cluster.tf
+++ b/caasp-openstack-terraform/caasp-cluster.tf
@@ -69,6 +69,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_admin" {
   description = "CaaSP security group for admin"
 
   rule {
+    from_port   = 80
+    to_port     = 80
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
     from_port   = 443
     to_port     = 443
     ip_protocol = "tcp"
@@ -78,6 +85,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_admin" {
   rule {
     from_port   = 4505
     to_port     = 4506
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 389
+    to_port     = 389
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }


### PR DESCRIPTION
Masters run kube-proxy too, we should allow access to these ports by
default in our tooling.