### PR TITLE
Pin all testinfra dependencies

### DIFF
--- a/testinfra/requirements.txt
+++ b/testinfra/requirements.txt
@@ -1,4 +1,19 @@
-testinfra
-pytest>=3.1.3
-paramiko
-cffi<1.11.1
+# Direct Dependencies
+testinfra==1.8.0
+pytest==3.2.2
+paramiko==2.3.1
+
+# Transitive Dependencies
+cffi==1.11.0
+asn1crypto==0.23.0
+bcrypt==3.1.3
+cryptography==2.0.3
+enum34==1.1.6
+idna==2.6
+ipaddress==1.0.18
+paramiko==2.3.1
+py==1.4.34
+pyasn1==0.3.6
+pycparser==2.18
+PyNaCl==1.1.2
+six==1.11.0


### PR DESCRIPTION
This will help avoid unexpected suprises when upstream projects
release new + incompatible versions.