### PR TITLE
caasp-openstack: enable passing name to subcommands

### DIFF
--- a/caasp-openstack-heat/caasp-openstack
+++ b/caasp-openstack-heat/caasp-openstack
@@ -133,6 +133,8 @@ update_stack() {
   [ -z $IMAGE ] && error "Option --image is required"
 
   local stack_name=$(cat .stack_name)
+  [ -n $NAME ] && stack_name=$NAME
+
   log "Updating Stack with ID $stack_name"
 
   source $OPENRC_FILE
@@ -147,11 +149,13 @@ update_stack() {
 
 destroy_stack() {
   local stack_name=$(cat .stack_name)
+  [ -n $NAME ] && stack_name=$NAME
+
   log "Deleting Stack with name $stack_name"
 
   source $OPENRC_FILE
   openstack stack delete --yes --wait $stack_name
-  rm .stack_name
+  rm -f .stack_name
 }
 
 # main


### PR DESCRIPTION
when you have deployed multiple stacks this is helpful as the
.stack_name file will be outdated

Signed-off-by: Maximilian Meister <mmeister@suse.de>