### PR TITLE
Visit the root before trying to download the kubeconfig file

### DIFF
--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -134,14 +134,21 @@ feature "Boostrap cluster" do
   end
 
   scenario "User downloads the kubeconfig file" do
-    click_on "kubectl config"
-    expect(page).to have_current_path("/auth/ldap", only_path: true)
+    visit "/"
+
+    expect(page).to have_text("You currently have no nodes to be accepted for bootstrapping", wait: 120)
+
+    expect(page).to have_text("kubectl config")
+    with_screenshot(name: :download_kubeconfig) do
+      click_on "kubectl config"
+    end
+    expect(page).to have_text("Log in to Your Account")
     with_screenshot(name: :oidc_login) do
       fill_in "login", with: "test@test.com"
       fill_in "password", with: "password"
       click_button "Login"
     end
-    expect(page.body).to have_text("apiVersion")
+    expect(page).to have_text("apiVersion")
     File.write("kubeconfig", Nokogiri::HTML(page.body).xpath("//pre").text)
   end
 end


### PR DESCRIPTION
Also, make the test less flaky by doing the proper waits.

Backport of https://github.com/kubic-project/automation/pull/162