### PR TITLE
[2.0] Fill in Dashboard's external FQDN during bootstrap

### DIFF
--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -113,6 +113,12 @@ feature "Boostrap cluster" do
     puts ">>> Configuring last settings"
     with_screenshot(name: :bootstrap_cluster_settings) do
       fill_in "settings_apiserver", with: environment["kubernetesHost"]
+      # TODO: Add a top level environment.json field with this value
+      environment["minions"].each do |minion|
+        if minion["role"] == "admin"
+          fill_in "settings_dashboard_external_fqdn", with: minion["fqdn"]
+        end
+      end
     end
     puts "<<< Last settings configured"
 


### PR DESCRIPTION
Part of bsc#1062291

Backport of https://github.com/kubic-project/automation/pull/164