### PR TITLE
clean up tfvars examples

### DIFF
--- a/caasp-kvm/terraform.tfvars.example
+++ b/caasp-kvm/terraform.tfvars.example
@@ -12,36 +12,7 @@
 #####################
 # Cluster variables #
 #####################
-# The latest version of the CaaSP image in the devel channel:
-#caasp_img_source_url = "channel://devel"
-#caasp_img_source_url = "channel://staging_a"
-#caasp_img_source_url = "channel://staging_b"
-#caasp_img_source_url = "channel://release"
-#caasp_img_source_url = "file:///path/to/local/image"
-#caasp_img_source_url = "http://download.suse.de/ibs/Devel:/CASP:/1.0:/ControllerNode/images/SUSE-CaaS-Platform-1.0-KVM-and-Xen.x86_64.qcow2"
-
-# Admin Variables
-#caasp_admin_memory = 4096
-#caasp_admin_vcpu = 4
-
-# Master Variables
-#caasp_master_count  = 1
-#caasp_master_memory = 2048
-#caasp_master_vcpu   = 2
-
-# Worker Variables
-#caasp_worker_count  = 2
-#caasp_worker_memory = 2048
-#caasp_worker_vcpu   = 2
-
 # A range that doesn't conflict with the SUSE network
 # and allows a similar naming.
 #caasp_net_network = "172.30.0.0/22"
 #caasp_net_mode = "route"
-
-####################
-# DevEnv variables #
-####################
-#kubic_salt_dir                      = "/home/user/caasp/salt/"
-#kubic_velum_dir                     = "/home/user/caasp/velum"
-#kubic_force_rebuild_velum_image     = false


### PR DESCRIPTION
Variables are now set by passing `-var foo=bar` flags to `terraform apply`.
Since these arguments take precedence over the tfvars file, some of the
variables defined inside of this file can be removed.

Signed-off-by: Thomas Hipp <thipp@suse.de>