### PR TITLE
[2.0] Velum-bootstrap should use the correct URL to access Velum

### DIFF
--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -51,7 +51,7 @@ Capybara.configure do |config|
   config.default_selector = :css
 
   if admin_minion
-    config.app_host = "https://#{admin_minion['addresses']['publicIpv4']}"
+    config.app_host = "https://#{admin_minion['fqdn']}"
   else
     config.app_host = "https://localhost"
   end


### PR DESCRIPTION
Velum bootstrap should be using the same name we expect end-users of
CaaSP to use when accessing the cluster.

Backport of https://github.com/kubic-project/automation/pull/170