### PR TITLE
Make remote libvirt hosts scenario easier

### DIFF
--- a/caasp-kvm/terraform.tfvars.example
+++ b/caasp-kvm/terraform.tfvars.example
@@ -34,6 +34,10 @@
 #caasp_worker_memory = 2048
 #caasp_worker_vcpu   = 2
 
+# A range that doesn't conflict with the SUSE network
+# and allows a similar naming.
+#caasp_net_network = "172.17.0.0/22"
+
 ####################
 # DevEnv variables #
 ####################


### PR DESCRIPTION
## Why

I do all the development on my laptop but I cannot run a caasp cluster because on it because it's not powerful enough.

However I do have a powerful workstation that I can use. By default the devenv creates a cluster located inside of a natted network that is reachable only by the virtualization host.

I could workaround that by using a ssh tunnel, but this is suboptimal, especially when I want to play with applications running on top of the kubernetes cluster.

## The changes

With this change the VMs are still created inside of a dedicated network managed by libvirt, but they are also reachable by the outside (once a dedicated routing rule is added to the host).

For example, given the hypervisor host ip address is `192.168.1.39` and all the machines are on the `192.168.200.0/24` network, the following command will allow another host to access these VMs:

```
ip -4 route add 192.168.200.0/24 via 192.168.1.39
```

Changing the network type from `nat` to `route` is not enough: the default subnet is used also by SUSE's R&D network. My laptop is always connected to this network, hence all the requests to the
`10.17.0.0/22` network are automatically routed to the VPN instead of my workstation.

This commit allows also to change the default subnet to use a different one that is not conflicting with SUSE's R&D network (like the `172.30.0.0/22` one).

**WARNING:** you cannot pick networks like `172.16.0.0/13` or `172.17.0.0/24` because the first one is being used by flannel, while the second one is used by docker. You should use something like `172.30.0.0/22`.

## My dev enviroment/workflow

For the sake of completeness (and reuse from others), all the source code is checked out on my laptop inside of `~/hacking/kubic`. This is where I make all my changes.

The whole `~/hacking/kubic` directory is automatically sent to my workstation (hostname `arrakis`) and kept in sync using [lsyncd](https://github.com/axkibe/lsyncd) (which has official openSUSE packages BTW).

The configuration file for `lsyncd` is saved inside of `~/hacking/kubic/lsyncd.conf`:

```lua
settings {
  logfile    = "/tmp/lsyncd.log",
  statusFile = "/tmp/lsyncd.status",
  nodaemon   = true,
}

sync {
  default.rsyncssh,
  source    = "/home/flavio/hacking/kubic",
  host      = "flavio@arrakis",
  targetdir = "/home/flavio/hacking/kubic",
  exclude   = {
    "automation/downloads/**",
    "*.tfstate",
    "*.tfstate.backup",
    "*.terraform" }
}
```

## Bonus points

In addition to making the cluster easier to be accessed, it's now possible to create bigger cluster spanning several virtualization hosts.

For example: I can bring up the admin node, 3 masters and 1 worker on my workstation then add 3 workers nodes hosted on my laptop. 😎 