### PR TITLE
Ignore `.terraform` directory inside `caasp-kvm`

### DIFF
--- a/caasp-kvm/.gitignore
+++ b/caasp-kvm/.gitignore
@@ -1,5 +1,6 @@
 *.qcow2
 *.tfstate*
 *.tar.xz
+.terraform
 terraform.tfvars
 crash.log


### PR DESCRIPTION
Since we are doing a `terraform init`, a `plugins` directory is created
inside `.terraform` resulting in a dirty state of the repository.