### PR TITLE
WIP and RFC: bring back caasp kvm qa project

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 ACTION=
 RUN_BUILD=
 RUN_DESTROY=
-ENABLE_DEVENV=
+VANILLA=
 
 MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
@@ -39,7 +39,7 @@ Usage:
     -m|--masters <INT>     Number of masters to build (Default: CAASP_NUM_MASTERS=$MASTERS)
     -w|--workers <INT>     Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
     -i|--image <STR>       Image to use (Default: CAASP_IMAGE=$IMAGE)
-    -d|--devenv            Enable devenv (Default: false)
+    --vanilla              Do not inject devenv code, use vanilla caasp (Default: false)
 
   * Destroying a cluster
 
@@ -96,8 +96,8 @@ while [[ $# > 0 ]] ; do
       ACTION=1
       RUN_BUILD=1
       ;;
-    -d|--devenv)
-      ENABLE_DEVENV=1
+    --vanilla)
+      VANILLA=1
       ;;
     -m|--masters)
       MASTERS="$2"
@@ -206,7 +206,10 @@ build() {
   # ln -f fails when the link already exists and points to the same file
   rm -f tf-modules/admin-node/main.tf
 
-  if [ -n "$ENABLE_DEVENV" ] ; then
+  if [ -n "$VANILLA" ] ; then
+    log "devenv mode disabled"
+    ln -s $(realpath tf-modules/admin-node/main.tf.vanilla) $(realpath tf-modules/admin-node/main.tf)
+  else
     log "devenv mode enabled"
     ln -s $(realpath tf-modules/admin-node/main.tf.devenv) $(realpath tf-modules/admin-node/main.tf)
 
@@ -227,9 +230,6 @@ build() {
     else
       log "Skipping Velum environment"
     fi
-  else
-    log "devenv mode disabled"
-    ln -s $(realpath tf-modules/admin-node/main.tf.vanilla) $(realpath tf-modules/admin-node/main.tf)
   fi
 
   log "Applying terraform configuration"

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -8,6 +8,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 ACTION=
 RUN_BUILD=
 RUN_DESTROY=
+ENABLE_DEVENV=
 
 MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
@@ -38,6 +39,7 @@ Usage:
     -m|--masters <INT>     Number of masters to build (Default: CAASP_NUM_MASTERS=$MASTERS)
     -w|--workers <INT>     Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
     -i|--image <STR>       Image to use (Default: CAASP_IMAGE=$IMAGE)
+    -d|--devenv            Enable devenv (Default: false)
 
   * Destroying a cluster
 
@@ -93,6 +95,9 @@ while [[ $# > 0 ]] ; do
     -b|--build)
       ACTION=1
       RUN_BUILD=1
+      ;;
+    -d|--devenv)
+      ENABLE_DEVENV=1
       ;;
     -m|--masters)
       MASTERS="$2"
@@ -198,26 +203,37 @@ build() {
   log "Downloading CaaSP KVM Image"
   $DIR/../misc-tools/download-image --proxy "${PROXY}" --type kvm $IMAGE
 
-  if [ -n "$CAASP_VELUM_DIR" ] ; then
-    log "Building Velum Development Image"
-    $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${PROXY}"
+  # ln -f fails when the link already exists and points to the same file
+  rm -f tf-modules/admin-node/main.tf
 
-    log "Creating Velum Directories"
-    mkdir -p "$CAASP_VELUM_DIR/tmp" "$CAASP_VELUM_DIR/log" "$CAASP_VELUM_DIR/vendor/bundle"
+  if [ -n "$ENABLE_DEVENV" ] ; then
+    log "devenv mode enabled"
+    ln -s $(realpath tf-modules/admin-node/main.tf.devenv) $(realpath tf-modules/admin-node/main.tf)
 
-    log "Copying CaaSP Container Manifests"
-    local injected="$(realpath injected-caasp-container-manifests)"
-    rm -rf $injected/*
-    cp -r $CAASP_MANIFESTS_DIR/* "$injected/"
+    if [ -n "$CAASP_VELUM_DIR" ] ; then
+      log "Building Velum Development Image"
+      $DIR/tools/build-velum-image "$CAASP_VELUM_DIR" "${PROXY}"
 
-    log "Patching Container Manifests"
-    $DIR/tools/fix-kubelet-manifest -o $injected/public.yaml $injected/public.yaml
+      log "Creating Velum Directories"
+      mkdir -p "$CAASP_VELUM_DIR/tmp" "$CAASP_VELUM_DIR/log" "$CAASP_VELUM_DIR/vendor/bundle"
+
+      log "Copying CaaSP Container Manifests"
+      local injected="$(realpath injected-caasp-container-manifests)"
+      rm -rf $injected/*
+      cp -r $CAASP_MANIFESTS_DIR/* "$injected/"
+
+      log "Patching Container Manifests"
+      $DIR/tools/fix-kubelet-manifest -o $injected/public.yaml $injected/public.yaml
+    else
+      log "Skipping Velum environment"
+    fi
   else
-    log "Skipping Velum environment"
+    log "devenv mode disabled"
+    ln -s $(realpath tf-modules/admin-node/main.tf.vanilla) $(realpath tf-modules/admin-node/main.tf)
   fi
 
   log "Applying terraform configuration"
-  terraform init && terraform apply $TF_ARGS
+  terraform get && terraform init && terraform apply $TF_ARGS
 
   $DIR/tools/generate-environment
   $DIR/../misc-tools/generate-ssh-config $ENVIRONMENT
@@ -230,7 +246,7 @@ build() {
 
 destroy() {
   log "Destroying terraform configuration"
-  terraform destroy -force $TF_ARGS && \
+  terraform get && terraform destroy -force $TF_ARGS && \
     rm -f "$ENVIRONMENT"
 }
 

--- a/caasp-kvm/cluster.tf
+++ b/caasp-kvm/cluster.tf
@@ -65,7 +65,7 @@ variable "caasp_worker_vcpu" {
 variable "caasp_domain_name" {
   type        = "string"
   default     = "devenv.caasp.suse.net"
-  description = "The amount of virtual CPUs for a worker"
+  description = "The default domain name"
 }
 
 variable "caasp_net_mode" {

--- a/caasp-kvm/tf-modules/admin-node/main.tf.devenv
+++ b/caasp-kvm/tf-modules/admin-node/main.tf.devenv
@@ -1,0 +1,82 @@
+# admin node with injected resources from the host. Useful for devenv
+
+resource "libvirt_domain" "admin" {
+  name      = "caasp_admin"
+  memory    = "${var.caasp_admin_memory}"
+  vcpu      = "${var.caasp_admin_vcpu}"
+  metadata   = "caasp-admin.${var.caasp_domain_name},admin,${count.index}"
+  cloudinit = "${libvirt_cloudinit.admin.id}"
+
+  disk {
+    volume_id = "${libvirt_volume.admin.id}"
+  }
+
+  network_interface {
+    network_id     = "${var.network_id}"
+    hostname       = "caasp-admin"
+    addresses      = ["${cidrhost("${var.caasp_net_network}", 256)}"]
+    wait_for_lease = 1
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+
+  filesystem {
+    source = "${var.kubic_salt_dir}"
+    target = "salt"
+    readonly = true
+  }
+
+  filesystem {
+    source = "${var.modified_container_manifests_dir}"
+    target = "caasp-container-manifests"
+    readonly = true
+  }
+
+  filesystem {
+    source = "${var.kubic_velum_dir}"
+    target = "velum"
+    readonly = true
+  }
+
+  filesystem {
+    source = "${var.devel_scripts_dir}"
+    target = "devel-scripts"
+    readonly = true
+  }
+
+  filesystem {
+    source = "${var.docker_images_dir}"
+    target = "devel-docker-images"
+    readonly = true
+  }
+
+  connection {
+    type     = "ssh"
+    user     = "root"
+    password = "linux"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "while [[ ! -f /var/run/docker.pid ]]; do echo waiting for docker to start; sleep 1; done",
+      "docker load -i /var/lib/misc/devel-docker-images/*.tar",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "for i in `ls -1 /opt/bin/autorun*.sh /opt/bin/autorun*/*.sh` ; do sh $i ; done",
+    ]
+  }
+}
+
+output "libvirt_id" {
+  value = "${libvirt_domain.admin.id}"
+}
+
+output "ip" {
+  value = "${libvirt_domain.admin.network_interface.0.addresses.0}"
+}

--- a/caasp-kvm/tf-modules/admin-node/main.tf.vanilla
+++ b/caasp-kvm/tf-modules/admin-node/main.tf.vanilla
@@ -1,0 +1,34 @@
+# admin node without any injected resources from the host. Useful to reproduce
+# customer bugs or to perform QA tasks
+
+resource "libvirt_domain" "admin" {
+  name      = "caasp_admin"
+  memory    = "${var.caasp_admin_memory}"
+  vcpu      = "${var.caasp_admin_vcpu}"
+  metadata   = "caasp-admin.${var.caasp_domain_name},admin,${count.index}"
+  cloudinit = "${libvirt_cloudinit.admin.id}"
+
+  disk {
+    volume_id = "${libvirt_volume.admin.id}"
+  }
+
+  network_interface {
+    network_id     = "${var.network_id}"
+    hostname       = "caasp-admin"
+    addresses      = ["${cidrhost("${var.caasp_net_network}", 256)}"]
+    wait_for_lease = 1
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+}
+
+output "libvirt_id" {
+  value = "${libvirt_domain.admin.id}"
+}
+
+output "ip" {
+  value = "${libvirt_domain.admin.network_interface.0.addresses.0}"
+}

--- a/caasp-kvm/tf-modules/admin-node/shared.tf
+++ b/caasp-kvm/tf-modules/admin-node/shared.tf
@@ -1,0 +1,11 @@
+resource "libvirt_volume" "admin" {
+  name           = "caasp_admin.qcow2"
+  pool           = "${var.pool}"
+  base_volume_id = "${var.base_volume_id}"
+}
+
+resource "libvirt_cloudinit" "admin" {
+  name      = "caasp_admin_cloud_init.iso"
+  pool      = "${var.pool}"
+  user_data = "${file("cloud-init/admin.cfg")}"
+}

--- a/caasp-kvm/tf-modules/admin-node/variables.tf
+++ b/caasp-kvm/tf-modules/admin-node/variables.tf
@@ -1,0 +1,59 @@
+variable "pool" {
+  type = "string"
+  description = "pool to be used to store all the volumes"
+}
+
+variable "base_volume_id" {
+  type = "string"
+  description = "id of the base volume to use"
+}
+
+variable "caasp_admin_memory" {
+  type = "string"
+  description = "The amount of RAM for a admin node"
+}
+
+variable "caasp_admin_vcpu" {
+  type = "string"
+  description = "The amount of virtual CPUs for a admin node"
+}
+
+variable "caasp_domain_name" {
+  type        = "string"
+  description = "The default domain name"
+}
+
+variable "network_id" {
+  type = "string"
+  description = "The ID of the libvirt network to use"
+}
+
+variable "caasp_net_network" {
+  type        = "string"
+  description = "Network used by the caasp cluster"
+}
+
+variable "kubic_salt_dir" {
+  type = "string"
+  description = "Path to the directory where https://github.com/kubic-project/salt/ has been cloned into"
+}
+
+variable "kubic_velum_dir" {
+  type = "string"
+  description = "Path to the directory where https://github.com/kubic-project/velum has been cloned into"
+}
+
+variable "devel_scripts_dir" {
+  type = "string"
+  description = "Path to the directory where the development scripts are located"
+}
+
+variable "docker_images_dir" {
+  type = "string"
+  description = "Path to the directory where the development docker images are located"
+}
+
+variable "modified_container_manifests_dir" {
+  type = "string"
+  description = "Path to the directory where the modified container manifests are located"
+}


### PR DESCRIPTION
The purpose of this PR is to fill the gap between `automation/caasp-kvm` and the original caasp-kvm project.

Without this PR `automation/caasp-kvm` creates caasp clusters where the admin node has development code injected. This is useful for development purposes, but it doesn't help when doing QA or debugging tasks.

With this PR the `caasp-kvm` script has been extended with a new flag: `--devenv`. By default the flag is set to false, leading to the quick creation of "vanilla" caasp clusters where the admin node doesn't have any development code injected.
On the opposite, when the `--devenv` flag is used, the cluster will be created in the old usual way.

Due to the lack of conditionals I resorted to the usage of a terraform module to describe the admin node. This has been done to reduce the code duplication.

This is a WIP and, most important of all, a RFC. If others are fine with this approach I'll extend the documentation of the project to cover this new use case.

