### PR TITLE
Make the kvm network mode configurable

### DIFF
--- a/caasp-kvm/README.md
+++ b/caasp-kvm/README.md
@@ -142,6 +142,7 @@ First of all you have to pick a different subnet for the caasp network. This
 is done by creating a `terraform.tfvars` with the following line:
 
 ```hcl
+caasp_net_network = "route"
 caasp_net_network = "172.30.0.0/22"
 ```
 

--- a/caasp-kvm/cluster.tf
+++ b/caasp-kvm/cluster.tf
@@ -68,6 +68,12 @@ variable "caasp_domain_name" {
   description = "The amount of virtual CPUs for a worker"
 }
 
+variable "caasp_net_mode" {
+  type        = "string"
+  default     = "nat"
+  description = "Network mode used by the caasp cluster"
+}
+
 variable "caasp_net_network" {
   type        = "string"
   default     = "10.17.0.0/22"
@@ -108,7 +114,7 @@ resource "libvirt_volume" "caasp_img" {
 ##############
 resource "libvirt_network" "network" {
     name      = "caasp-net"
-    mode      = "route"
+    mode      = "${var.caasp_net_mode}"
     domain    = "${var.caasp_domain_name}"
     addresses = ["${var.caasp_net_network}"]
 }

--- a/caasp-kvm/terraform.tfvars.example
+++ b/caasp-kvm/terraform.tfvars.example
@@ -36,7 +36,8 @@
 
 # A range that doesn't conflict with the SUSE network
 # and allows a similar naming.
-#caasp_net_network = "172.17.0.0/22"
+#caasp_net_network = "172.30.0.0/22"
+#caasp_net_mode = "route"
 
 ####################
 # DevEnv variables #


### PR DESCRIPTION
We cannot leave the network mode to be "route" by default, otherwise the network will be broken inside of the VMs when the default subnet is being used.