### PR TITLE
Move manifests into a subdirectory

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -211,7 +211,12 @@ build() {
     cp -r $CAASP_MANIFESTS_DIR/* "$injected/"
 
     log "Patching Container Manifests"
-    $DIR/tools/fix-kubelet-manifest -o $injected/public.yaml $injected/public.yaml
+    # TODO: Remove the if/else once https://github.com/kubic-project/caasp-container-manifests/pull/135 is merged
+    if [ -f "$injected/manifests/public.yaml" ]; then
+      $DIR/tools/fix-kubelet-manifest -o $injected/manifests/public.yaml $injected/manifests/public.yaml
+    else
+      $DIR/tools/fix-kubelet-manifest -o $injected/public.yaml $injected/public.yaml
+    fi
   else
     log "Skipping Velum environment"
   fi


### PR DESCRIPTION
This allows us to remove the public.yaml / private.yaml hardcodes, which in
turn allows us to split the public / private pods into more specific pods
matching the typical patterns used to deploy workloads in K8S.

See also - https://github.com/kubic-project/caasp-container-manifests/pull/135