### PR TITLE
CaaSP OS Heat: Add optional disks to workers

### DIFF
--- a/caasp-openstack-heat/caasp-stack-worker.yaml
+++ b/caasp-openstack-heat/caasp-stack-worker.yaml
@@ -39,6 +39,14 @@ parameters:
   admin_node_ip:
     type: string
     description: Admin Node IP
+  num_volumes:
+    type: number
+    description: Number of volumes to create and attach to the worker
+    default: 0
+  volume_size:
+    type: number
+    description: Size of each volume in GB.
+    default: 10
 
 resources:
   worker:
@@ -73,3 +81,13 @@ resources:
           params:
             $admin_node: { get_param: admin_node_ip }
             $root_password: { get_param: root_password }
+
+  worker_volumes:
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: { get_param: num_volumes }
+      resource_def:
+        type: volume-with-attachment.yaml
+        properties:
+          instance_id: { get_resource: worker }
+          volume_size: { get_param: volume_size }

--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -17,6 +17,8 @@ parameter_groups:
       - master_count
       - worker_flavor
       - worker_count
+      - worker_num_volumes
+      - worker_volume_size
 
   - label: network
     description: Network Parameters
@@ -70,6 +72,14 @@ parameters:
     type: number
     description: Number of Worker nodes to boot
     default: 5
+  worker_num_volumes:
+    type: number
+    description: Number of volumes to create and attach to each worker
+    default: 0
+  worker_volume_size:
+    type: number
+    description: Size of each worker-attached volume in GB
+    default: 10
   root_password:
     type: string
     description: Root Password for the VMs
@@ -289,3 +299,5 @@ resources:
           keypair: { get_resource: keypair }
           root_password: { get_param: root_password }
           admin_node_ip: { get_attr: [admin, first_address] }
+          num_volumes: { get_param: worker_num_volumes }
+          volume_size: { get_param: worker_volume_size }

--- a/caasp-openstack-heat/heat-environment.yaml.example
+++ b/caasp-openstack-heat/heat-environment.yaml.example
@@ -7,3 +7,5 @@ parameters:
   external_net: ext-net
   internal_net_cidr: 172.24.0.0/24
   dns_nameserver: 172.24.0.2
+  worker_num_volumes: 0
+  worker_volume_size: 10

--- a/caasp-openstack-heat/volume-with-attachment.yaml
+++ b/caasp-openstack-heat/volume-with-attachment.yaml
@@ -1,0 +1,23 @@
+heat_template_version: 2015-04-30
+
+parameters:
+  volume_size:
+    type: number
+    description: Size of volume in GB to attach to instance
+    default: 10
+  instance_id:
+    type: string
+    description: Server to attach volume to
+
+resources:
+  volume:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: volume_size }
+      description: Volume for stack
+
+  volume_attachment:
+    type: OS::Cinder::VolumeAttachment
+    properties:
+      volume_id: { get_resource: volume }
+      instance_uuid: { get_param: instance_id }


### PR DESCRIPTION
For building applications on CaaSP that leverage host storage, add
ability to specify in the heat environment file that workers can have a
configurable number of disks added with a configurable size. Default is
to add zero disks, and default disk size is 10 GB.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>