### PR TITLE
Use dashboardExternalHost instead of admin FQDN for Velum URL

### DIFF
--- a/caasp-openstack-heat/caasp-openstack
+++ b/caasp-openstack-heat/caasp-openstack
@@ -58,7 +58,9 @@ check_file() { if [ ! -f $1 ]; then error "File $1 doesn't exist!"; fi }
 while [[ $# -gt 0 ]] ; do
   case $1 in
     -n|--name)
-      NAME="$2"
+      # Convert name to lower cases, as cloud-init will do with the machines
+      # hostname.
+      NAME="${2,,}"
       shift
       ;;
     -o|--openrc)

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -49,12 +49,7 @@ Capybara.configure do |config|
   config.ignore_hidden_elements = true
   config.visible_text_only = true
   config.default_selector = :css
-
-  if admin_minion
-    config.app_host = "https://#{admin_minion['fqdn']}"
-  else
-    config.app_host = "https://localhost"
-  end
+  config.app_host = "https://#{environment["dashboardExternalHost"]}"
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
dashboardExternalHost is the name we expect users to access Velum via. We should be using it for bootstrapping Velum.

Additionally, covert stack names to lowercase to match cloud-init behaviour.