### PR TITLE
Load images during Velum bootstrap

### DIFF
--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -31,7 +31,7 @@ Capybara.register_driver :poltergeist do |app|
     js_errors:         false,
     phantomjs_options: [
       "--proxy-type=none",
-      "--load-images=no"
+      "--load-images=yes"
     ]
   }
   # NOTE: uncomment the line below to get more info on the current run.


### PR DESCRIPTION
This allows for more accurate screenshots during CI runs.