### PR TITLE
[2.0] Add 'kubernetesExternalHost' to Heat environment

### DIFF
--- a/caasp-openstack-heat/tools/generate-environment
+++ b/caasp-openstack-heat/tools/generate-environment
@@ -30,7 +30,7 @@ MASTER_NOVA_JSON=$(set -o pipefail; openstack server show -f json $MASTER_ID)
 MASTER_MINION_JSON=$(set -o pipefail; echo "$MASTER_NOVA_JSON" | jq -c "{role: \"master\", fqdn: .name, addresses: {publicIpv4: .addresses | split(\"=\") | .[1] | split(\",\") | .[1] | gsub(\" \"; \"\"), privateIpv4: .addresses | split(\"=\") | .[1] | split(\",\") | .[0]}, index: \"$INDEX\", minionId: (.id | gsub(\"-\"; \"\"))}")
 MASTER_PUBLIC_IPV4=$(set -o pipefail; echo "$MASTER_NOVA_JSON" | jq -r ".addresses | split(\"=\") | .[1] | split(\",\") | .[1] | gsub(\" \"; \"\")")
 ENVIRONMENT=$(set -o pipefail; echo "$ENVIRONMENT" | jq ".minions |= . + [$MASTER_MINION_JSON]")
-ENVIRONMENT=$(set -o pipefail; echo "$ENVIRONMENT" | jq ".kubernetesHost |= \"$MASTER_PUBLIC_IPV4\"")
+ENVIRONMENT=$(set -o pipefail; echo "$ENVIRONMENT" | jq ".kubernetesExternalHost |= \"$MASTER_PUBLIC_IPV4\"")
 
 INDEX=$((INDEX + 1))
 


### PR DESCRIPTION
For velum-bootstrap tooling to work, it now requires a
'kubernetesExternalHost' field to be present. Add this into the
environment.json file generation in the OpenStack Heat tooling.
Trivially select the first master as the external kubernetes host.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>
 
Backport of https://github.com/kubic-project/automation/pull/193