### PR TITLE
Add a lock around OS jobs

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
@@ -22,12 +22,14 @@ openstackTypeOptions.adminFlavor = env.ADMIN_FLAVOR
 openstackTypeOptions.masterFlavor = env.MASTER_FLAVOR
 openstackTypeOptions.workerFlavor = env.WORKER_FLAVOR
 
-coreKubicProjectPeriodic(
-    // Prefer m1.large workers, fallback to any leap42.3 worker.
-    nodeLabel: 'leap42.3&&m1.large||leap42.3',
-    environmentType: 'openstack',
-    environmentTypeOptions: openstackTypeOptions,
-    environmentDestroy: env.ENVIRONMENT_DESTROY,
-    masterCount: env.MASTER_COUNT.toInteger(),
-    workerCount: env.WORKER_COUNT.toInteger()
-)
+lock('openstack-single-user') {
+    coreKubicProjectPeriodic(
+        // Prefer m1.large workers, fallback to any leap42.3 worker.
+        nodeLabel: 'leap42.3&&m1.large||leap42.3',
+        environmentType: 'openstack',
+        environmentTypeOptions: openstackTypeOptions,
+        environmentDestroy: env.ENVIRONMENT_DESTROY,
+        masterCount: env.MASTER_COUNT.toInteger(),
+        workerCount: env.WORKER_COUNT.toInteger()
+    )
+}

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade-openstack
@@ -28,128 +28,130 @@ openstackTypeOptions.adminFlavor = env.ADMIN_FLAVOR
 openstackTypeOptions.masterFlavor = env.MASTER_FLAVOR
 openstackTypeOptions.workerFlavor = env.WORKER_FLAVOR
 
-// Deploy using the "old" branch
-// TODO: This is using the "new" jenkins-lib code, which may no longer
-// be compatible with the "old" deployment...
-coreKubicProjectPeriodic(
-    // Prefer m1.large workers, fallback to any leap42.3 worker.
-    nodeLabel: 'leap42.3&&m1.large||leap42.3',
-    environmentType: 'openstack',
-    environmentTypeOptions: openstackTypeOptions,
-    environmentDestroy: env.ENVIRONMENT_DESTROY,
-    gitBranch: fromBranch,
-    gitIgnorePullRequest: true,
-    masterCount: env.MASTER_COUNT.toInteger(),
-    workerCount: env.WORKER_COUNT.toInteger()
-) {
-    stage('Install Upgrade Repo') {
-        def parallelSteps = [:]
+lock('openstack-single-user') {
+    // Deploy using the "old" branch
+    // TODO: This is using the "new" jenkins-lib code, which may no longer
+    // be compatible with the "old" deployment...
+    coreKubicProjectPeriodic(
+        // Prefer m1.large workers, fallback to any leap42.3 worker.
+        nodeLabel: 'leap42.3&&m1.large||leap42.3',
+        environmentType: 'openstack',
+        environmentTypeOptions: openstackTypeOptions,
+        environmentDestroy: env.ENVIRONMENT_DESTROY,
+        gitBranch: fromBranch,
+        gitIgnorePullRequest: true,
+        masterCount: env.MASTER_COUNT.toInteger(),
+        workerCount: env.WORKER_COUNT.toInteger()
+    ) {
+        stage('Install Upgrade Repo') {
+            def parallelSteps = [:]
 
-        environment.minions.each { minion ->
-            def installUpgradeRepo = {
-                shOnMinion(minion: minion, script: 'echo "[main]" > /etc/zypp/vendors.d/vendors.conf')
-                shOnMinion(minion: minion, script: 'echo "vendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" >> /etc/zypp/vendors.d/vendors.conf')
-                shOnMinion(minion: minion, script: 'systemctl disable --now transactional-update.timer')
-                shOnMinion(minion: minion, script: "zypper ar --refresh --no-gpgcheck ${updateRepo}")
-                shOnMinion(minion: minion, script: '/usr/sbin/transactional-update cleanup dup salt')
-            }
-
-            parallelSteps.put("${minion.role}-${minion.index}", installUpgradeRepo)
-        }
-
-        timeout(120) {
-            parallel(parallelSteps)
-        }
-    }
-
-    // Upgrade the admin node before siwtching branches, as we
-    // need to use the "old" velum-bootstrap for this step, we're
-    // using the "old" velum still.
-    stage('Upgrade Admin Node') {
-        // Find the admin node
-        def adminNode
-        environment.minions.each { minion ->
-            if (minion.role == 'admin') {
-                adminNode = minion
-                break
-            }
-        }
-
-        // Refresh Salt Grains
-        shOnMinion(minion: adminNode, script: "docker exec -i $(docker ps | grep salt-master | awk '{print $1}') salt --batch 20 '*' saltutil.refresh_grains")
-
-        // Upgrade the admin node
-        timeout(10) {
-            dir('automation/velum-bootstrap') {
-                sh(script: './velum-interactions --setup')
-            }
-        }
-
-        timeout(60) {
-            try {
-                dir('automation/velum-bootstrap') {
-                    withEnv([
-                        "ENVIRONMENT=${WORKSPACE}/environment.json",
-                    ]) {
-                        sh(script: "./velum-interactions --update-admin")
-                    }
+            environment.minions.each { minion ->
+                def installUpgradeRepo = {
+                    shOnMinion(minion: minion, script: 'echo "[main]" > /etc/zypp/vendors.d/vendors.conf')
+                    shOnMinion(minion: minion, script: 'echo "vendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" >> /etc/zypp/vendors.d/vendors.conf')
+                    shOnMinion(minion: minion, script: 'systemctl disable --now transactional-update.timer')
+                    shOnMinion(minion: minion, script: "zypper ar --refresh --no-gpgcheck ${updateRepo}")
+                    shOnMinion(minion: minion, script: '/usr/sbin/transactional-update cleanup dup salt')
                 }
-            } finally {
-                dir('automation/velum-bootstrap') {
-                    junit "velum-bootstrap.xml"
-                    try {
-                        archiveArtifacts(artifacts: "screenshots/**")
-                        archiveArtifacts(artifacts: "kubeconfig")
-                    } catch (Exception exc) {
-                        echo "Failed to Archive Artifacts"
-                    }
+
+                parallelSteps.put("${minion.role}-${minion.index}", installUpgradeRepo)
+            }
+
+            timeout(120) {
+                parallel(parallelSteps)
+            }
+        }
+
+        // Upgrade the admin node before siwtching branches, as we
+        // need to use the "old" velum-bootstrap for this step, we're
+        // using the "old" velum still.
+        stage('Upgrade Admin Node') {
+            // Find the admin node
+            def adminNode
+            environment.minions.each { minion ->
+                if (minion.role == 'admin') {
+                    adminNode = minion
+                    break
                 }
             }
-        }
-    }
 
-    stage('Switch to new branch') {
-        // Move git checkouts to the "new" branches
-        cloneAllKubicRepos(
-            gitBase: 'https://github.com/kubic-project',
-            branch: toBranch,
-            credentialsId: 'github-token'
-        )
-    }
+            // Refresh Salt Grains
+            shOnMinion(minion: adminNode, script: "docker exec -i $(docker ps | grep salt-master | awk '{print $1}') salt --batch 20 '*' saltutil.refresh_grains")
 
-    stage('Upgrade Minions') {
-        // Upgrade the minions
-        timeout(10) {
-            dir('automation/velum-bootstrap') {
-                sh(script: './velum-interactions --setup')
-            }
-        }
-
-        timeout(120) {
-            try {
+            // Upgrade the admin node
+            timeout(10) {
                 dir('automation/velum-bootstrap') {
-                    withEnv([
-                        "ENVIRONMENT=${WORKSPACE}/environment.json",
-                    ]) {
-                        sh(script: "./velum-interactions --update-minions")
-                    }
+                    sh(script: './velum-interactions --setup')
                 }
-            } finally {
-                dir('automation/velum-bootstrap') {
-                    junit "velum-bootstrap.xml"
-                    try {
-                        archiveArtifacts(artifacts: "screenshots/**")
-                        archiveArtifacts(artifacts: "kubeconfig")
-                    } catch (Exception exc) {
-                        echo "Failed to Archive Artifacts"
+            }
+
+            timeout(60) {
+                try {
+                    dir('automation/velum-bootstrap') {
+                        withEnv([
+                            "ENVIRONMENT=${WORKSPACE}/environment.json",
+                        ]) {
+                            sh(script: "./velum-interactions --update-admin")
+                        }
+                    }
+                } finally {
+                    dir('automation/velum-bootstrap') {
+                        junit "velum-bootstrap.xml"
+                        try {
+                            archiveArtifacts(artifacts: "screenshots/**")
+                            archiveArtifacts(artifacts: "kubeconfig")
+                        } catch (Exception exc) {
+                            echo "Failed to Archive Artifacts"
+                        }
                     }
                 }
             }
         }
-    }
 
-    stage('Run Post-Upgrade Tests') {
-        // TODO: Add some cluster tests, e.g. booting pods, checking they work, etc
-        runTestInfra(environment: environment)
+        stage('Switch to new branch') {
+            // Move git checkouts to the "new" branches
+            cloneAllKubicRepos(
+                gitBase: 'https://github.com/kubic-project',
+                branch: toBranch,
+                credentialsId: 'github-token'
+            )
+        }
+
+        stage('Upgrade Minions') {
+            // Upgrade the minions
+            timeout(10) {
+                dir('automation/velum-bootstrap') {
+                    sh(script: './velum-interactions --setup')
+                }
+            }
+
+            timeout(120) {
+                try {
+                    dir('automation/velum-bootstrap') {
+                        withEnv([
+                            "ENVIRONMENT=${WORKSPACE}/environment.json",
+                        ]) {
+                            sh(script: "./velum-interactions --update-minions")
+                        }
+                    }
+                } finally {
+                    dir('automation/velum-bootstrap') {
+                        junit "velum-bootstrap.xml"
+                        try {
+                            archiveArtifacts(artifacts: "screenshots/**")
+                            archiveArtifacts(artifacts: "kubeconfig")
+                        } catch (Exception exc) {
+                            echo "Failed to Archive Artifacts"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Run Post-Upgrade Tests') {
+            // TODO: Add some cluster tests, e.g. booting pods, checking they work, etc
+            runTestInfra(environment: environment)
+        }
     }
 }


### PR DESCRIPTION
We currently use a single project for all OS jobs, and when they trigger each
night at the same time, we run out of quota. Add a lock around the outside for
now to ensure only 1 has access to the openstack project at the same time.