### PR TITLE
Update download URLs for 3.0

### DIFF
--- a/misc-files/download-urls.json
+++ b/misc-files/download-urls.json
@@ -1,9 +1,9 @@
 {
   "baseurl": {
     "devel": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode/",
-    "release": "http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/CASP20/",
-    "staging_a": "http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/CASP20:/Staging:/A/",
-    "staging_b": "http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/CASP20:/Staging:/B/"
+    "release": "http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/CASP30/",
+    "staging_a": "http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/CASP30:/Staging:/A/",
+    "staging_b": "http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/CASP30:/Staging:/B/"
   },
   "format_version": 1
 }


### PR DESCRIPTION
The release 3.0 project now exists on IBS, so it's time to update
the download URLs to match.