### PR TITLE
Ensure periodic builds are cleared at EOL

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.image-cacher
+++ b/jenkins-pipelines/Jenkinsfile.image-cacher
@@ -2,7 +2,7 @@ library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([
         [$class: 'org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger',

--- a/jenkins-pipelines/Jenkinsfile.image-loader-openstack
+++ b/jenkins-pipelines/Jenkinsfile.image-loader-openstack
@@ -2,7 +2,7 @@ library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([
         [$class: 'org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger',

--- a/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
@@ -2,7 +2,7 @@ library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([cron('@daily')]),
 ])

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly
@@ -2,7 +2,7 @@ library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([cron('@daily')]),
 ])

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
@@ -2,7 +2,7 @@ library "kubic-jenkins-library@${env.BRANCH_NAME}"
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([cron('@daily')]),
     parameters([

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
@@ -2,7 +2,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([cron('@daily')]),
     parameters([

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade-openstack
@@ -10,7 +10,7 @@ String updateRepo = 'http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Produ
 
 // Configure the build properties
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '31')),
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([cron('@daily')]),
     parameters([


### PR DESCRIPTION
Keep at most 31 days of build history for these jobs, which ensures
the history is eventually purged once a job is disabled due to the
removal of it's branch.