### PR TITLE
Heat: Change heat environment internal network settings

### DIFF
--- a/caasp-openstack-heat/heat-environment.yaml.example
+++ b/caasp-openstack-heat/heat-environment.yaml.example
@@ -5,7 +5,7 @@ parameters:
   master_flavor: m1.large
   worker_flavor: m1.large
   external_net: ext-net
-  internal_net_cidr: 172.24.0.0/24
-  dns_nameserver: 172.24.0.2
+  internal_net_cidr: 172.28.0.0/24
+  dns_nameserver: 172.28.0.2
   worker_num_volumes: 0
   worker_volume_size: 10


### PR DESCRIPTION
The previous settings were clashing with CaaSP 2.0's default k8s service
network (172.24.0.0). Change this to 172.25.0.0.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>