### PR TITLE
Heat: Enable admin NTP server

### DIFF
--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -153,6 +153,9 @@ resources:
         - protocol: tcp
           port_range_min: 389
           port_range_max: 389
+        - protocol: udp
+          port_range_min: 123
+          port_range_max: 123
 
   secgroup_master:
     type: OS::Neutron::SecurityGroup
@@ -233,6 +236,15 @@ resources:
 
             suse_caasp:
               role: admin
+
+            ntp:
+              servers:
+                - 0.opensuse.pool.ntp.org
+                - 1.opensuse.pool.ntp.org
+                - 2.opensuse.pool.ntp.org
+            runcmd:
+              - /usr/bin/systemctl enable --now ntpd
+
           params:
             $root_password: { get_param: root_password }
 


### PR DESCRIPTION
Enable the NTP server on the admin, and allow port 123 access to it so
that masters/workers may sync NTP.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>