### PR TITLE
fix bundler gemfile config

### DIFF
--- a/caasp-kvm/tools/build-velum-image
+++ b/caasp-kvm/tools/build-velum-image
@@ -129,6 +129,7 @@ set_env_variables() {
   local TMP_DIR=`mktemp -d`
   cat << EOF > $TMP_DIR/Dockerfile
 FROM sles12/velum:development_wip
+ENV BUNDLE_GEMFILE /srv/velum/Gemfile
 ENV BUNDLE_FROZEN 1
 ENV BUNDLE_PATH /var/lib/velum
 ENV BUNDLE_DISABLE_SHARED_GEMS 1


### PR DESCRIPTION
there seems to be a new behaviour with bundler 1.16.0 that the
gemfile config gets set to whatever working directory it was executed
from

make sure to override it with the correct path to the Gemfile

Signed-off-by: Maximilian Meister <mmeister@suse.de>