### PR TITLE
add name-prefix option to make multiple clusters on one kvm host possible

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -19,6 +19,7 @@ PARALLELISM=${CAASP_PARALLELISM:-1}
 CAASP_SALT_DIR=${CAASP_SALT_DIR:-$DIR/../../salt}
 CAASP_MANIFESTS_DIR=${CAASP_MANIFESTS_DIR:-$DIR/../../caasp-container-manifests}
 CAASP_VELUM_DIR=${CAASP_VELUM_DIR:-$DIR/../../velum}
+CAASP_NAME_PREFIX=${CAASP_NAME_PREFIX:-}
 
 ADMIN_RAM=${CAASP_ADMIN_RAM:-4096}
 ADMIN_CPU=${CAASP_ADMIN_CPU:-4}
@@ -128,6 +129,10 @@ while [[ $# > 0 ]] ; do
       CAASP_MANIFESTS_DIR="$2"
       shift
       ;;
+    --name-prefix)
+      CAASP_NAME_PREFIX="$2"
+      shift
+      ;;
     --velum-dir)
       CAASP_VELUM_DIR="$2"
       shift
@@ -194,6 +199,11 @@ fi
 if [ -n "$CAASP_MANIFESTS_DIR" ] ; then
   CAASP_MANIFESTS_DIR="$(realpath $CAASP_MANIFESTS_DIR)"
   log "Using Manifests dir: $CAASP_MANIFESTS_DIR"
+fi
+
+if [ -n "$CAASP_NAME_PREFIX" ] ; then
+  TF_ARGS="$TF_ARGS -var name_prefix=$CAASP_NAME_PREFIX"
+  log "Using name prefix for terraform: $CAASP_NAME_PREFIX"
 fi
 
 # Core methods

--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -64,6 +64,12 @@ variable "caasp_worker_vcpu" {
   description = "The amount of virtual CPUs for a worker"
 }
 
+variable "name_prefix" {
+  type        = "string"
+  default     = ""
+  description = "Optional prefix to be able to have multiple caasp clusters on one host"
+}
+
 variable "caasp_domain_name" {
   type        = "string"
   default     = "devenv.caasp.suse.net"
@@ -125,22 +131,22 @@ resource "libvirt_network" "network" {
 # Admin node #
 ##############
 resource "libvirt_volume" "admin" {
-  name           = "caasp_admin.qcow2"
+  name           = "${var.name_prefix}caasp_admin.qcow2"
   pool           = "${var.pool}"
   base_volume_id = "${libvirt_volume.caasp_img.id}"
 }
 
 resource "libvirt_cloudinit" "admin" {
-  name      = "caasp_admin_cloud_init.iso"
+  name      = "${var.name_prefix}caasp_admin_cloud_init.iso"
   pool      = "${var.pool}"
   user_data = "${file("cloud-init/admin.cfg")}"
 }
 
 resource "libvirt_domain" "admin" {
-  name      = "caasp_admin"
+  name      = "${var.name_prefix}caasp_admin"
   memory    = "${var.caasp_admin_memory}"
   vcpu      = "${var.caasp_admin_vcpu}"
-  metadata   = "caasp-admin.${var.caasp_domain_name},admin,${count.index}"
+  metadata   = "${var.name_prefix}caasp-admin.${var.caasp_domain_name},admin,${count.index}"
   cloudinit = "${libvirt_cloudinit.admin.id}"
 
   disk {
@@ -149,7 +155,7 @@ resource "libvirt_domain" "admin" {
 
   network_interface {
     network_id     = "${libvirt_network.network.id}"
-    hostname       = "caasp-admin"
+    hostname       = "${var.name_prefix}caasp-admin"
     addresses      = ["${cidrhost("${var.caasp_net_network}", 256)}"]
     wait_for_lease = 1
   }
@@ -220,7 +226,7 @@ output "ip_admin" {
 ###################
 
 resource "libvirt_volume" "master" {
-  name           = "caasp_master_${count.index}.qcow2"
+  name           = "${var.name_prefix}caasp_master_${count.index}.qcow2"
   pool           = "${var.pool}"
   base_volume_id = "${libvirt_volume.caasp_img.id}"
   count          = "${var.caasp_master_count}"
@@ -241,18 +247,18 @@ data "template_file" "master_cloud_init_user_data" {
 resource "libvirt_cloudinit" "master" {
   # needed when 0 master nodes are defined
   count     = "${var.caasp_master_count}"
-  name      = "caasp_master_cloud_init_${count.index}.iso"
+  name      = "${var.name_prefix}caasp_master_cloud_init_${count.index}.iso"
   pool      = "${var.pool}"
   user_data = "${element(data.template_file.master_cloud_init_user_data.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "master" {
   count      = "${var.caasp_master_count}"
-  name       = "caasp_master_${count.index}"
+  name       = "${var.name_prefix}caasp_master_${count.index}"
   memory     = "${var.caasp_master_memory}"
   vcpu       = "${var.caasp_master_vcpu}"
   cloudinit  = "${element(libvirt_cloudinit.master.*.id, count.index)}"
-  metadata   = "caasp-master-${count.index}.${var.caasp_domain_name},master,${count.index}"
+  metadata   = "${var.name_prefix}caasp-master-${count.index}.${var.caasp_domain_name},master,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 
   disk {
@@ -261,7 +267,7 @@ resource "libvirt_domain" "master" {
 
   network_interface {
     network_id     = "${libvirt_network.network.id}"
-    hostname       = "caasp-master-${count.index}"
+    hostname       = "${var.name_prefix}caasp-master-${count.index}"
     addresses      = ["${cidrhost("${var.caasp_net_network}", 512 + count.index)}"]
     wait_for_lease = 1
   }
@@ -294,7 +300,7 @@ output "masters" {
 ###################
 
 resource "libvirt_volume" "worker" {
-  name           = "caasp_worker_${count.index}.qcow2"
+  name           = "${var.name_prefix}caasp_worker_${count.index}.qcow2"
   pool           = "${var.pool}"
   base_volume_id = "${libvirt_volume.caasp_img.id}"
   count          = "${var.caasp_worker_count}"
@@ -315,18 +321,18 @@ data "template_file" "worker_cloud_init_user_data" {
 resource "libvirt_cloudinit" "worker" {
   # needed when 0 worker nodes are defined
   count     = "${var.caasp_worker_count}"
-  name      = "caasp_worker_cloud_init_${count.index}.iso"
+  name      = "${var.name_prefix}caasp_worker_cloud_init_${count.index}.iso"
   pool      = "${var.pool}"
   user_data = "${element(data.template_file.worker_cloud_init_user_data.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "worker" {
   count      = "${var.caasp_worker_count}"
-  name       = "caasp_worker_${count.index}"
+  name       = "${var.name_prefix}caasp_worker_${count.index}"
   memory     = "${var.caasp_worker_memory}"
   vcpu       = "${var.caasp_worker_vcpu}"
   cloudinit  = "${element(libvirt_cloudinit.worker.*.id, count.index)}"
-  metadata   = "caasp-worker-${count.index}.${var.caasp_domain_name},worker,${count.index}"
+  metadata   = "${var.name_prefix}caasp-worker-${count.index}.${var.caasp_domain_name},worker,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 
   disk {
@@ -335,7 +341,7 @@ resource "libvirt_domain" "worker" {
 
   network_interface {
     network_id     = "${libvirt_network.network.id}"
-    hostname       = "caasp-worker-${count.index}"
+    hostname       = "${var.name_prefix}caasp-worker-${count.index}"
     addresses      = ["${cidrhost("${var.caasp_net_network}", 768 + count.index)}"]
     wait_for_lease = 1
   }


### PR DESCRIPTION
This PR adds the option to add a prefix to all the used names for a kvm terraform setup via caasp-kvm. It changes nothing as long as you do not use the --name-prefix option.

There is one issue with this:
The network (caasp_net_network) has to be configurable for this to actually be useful as well.
But I have another way to come around this, which is to have DHCP assigned addresses on a bridged network. That will be the next PR.