### PR TITLE
Add kubeconfig path to environment.json

### DIFF
--- a/caasp-kvm/README.md
+++ b/caasp-kvm/README.md
@@ -83,8 +83,6 @@ sudo virsh pool-start default
 
 ## CLI Syntax
 
-    $ cd automation/caasp-kvm
-    $ ./caasp-kvm --help
     Usage:
 
       * Building a cluster
@@ -93,6 +91,7 @@ sudo virsh pool-start default
         -m|--masters <INT>     Number of masters to build (Default: CAASP_NUM_MASTERS=1)
         -w|--workers <INT>     Number of workers to build (Default: CAASP_NUM_WORKERS=2)
         -i|--image <STR>       Image to use (Default: CAASP_IMAGE=channel://devel)
+        --vanilla              Do not inject devenv code, use vanilla caasp (Default: false)
 
       * Destroying a cluster
 
@@ -111,8 +110,8 @@ sudo virsh pool-start default
 
       * Advanced Options
 
-        --admin-ram <INT>      RAM to allocate to admin node (Default: CAASP_ADMIN_RAM=2048)
-        --admin-cpu <INT>      CPUs to allocate to admin node (Default: CAASP_ADMIN_CPU=2)
+        --admin-ram <INT>      RAM to allocate to admin node (Default: CAASP_ADMIN_RAM=4096)
+        --admin-cpu <INT>      CPUs to allocate to admin node (Default: CAASP_ADMIN_CPU=4)
         --master-ram <INT>     RAM to allocate to master node(s) (Default: CAASP_MASTER_RAM=2048)
         --worker-ram <INT>     CPUs to allocate to master node(s) (Default: CAASP_MASTER_CPU=2)
         --master-cpu <INT>     RAM to allocate to worker node(s) (Default: CAASP_WORKER_RAM=2048)
@@ -131,7 +130,6 @@ sudo virsh pool-start default
       Destroy a cluster
 
       ./caasp-kvm --destroy
-
 
 # Notes
 

--- a/k8s-pod-tests/README.md
+++ b/k8s-pod-tests/README.md
@@ -1,4 +1,4 @@
-## Kubernetes pod creationg and scaling-up tests
+# Kubernetes pod creationg and scaling-up tests
 
 The yaml file(s) in the yaml/ directory are used to create test pods
 and then scale them up by increasing the number of replicas.
@@ -8,3 +8,40 @@ replicasCreationInterval build parameters.
 Use the k8s-pod-tests script for manual testing.
 
 See the jenkins-library repository for automated testing.
+
+## CLI Syntax
+
+    Usage:
+
+      * List pods
+
+        -l|--list                                       List running pods
+
+      * Creating a pod
+
+        -c|--create          <MANIFEST_FNAME>           Create a pod using a manifest file
+
+      * Deleting a pod
+
+        --delete             <MANIFEST_FNAME>           Delete a pod using a manifest file
+
+      * Scaling up a pod
+
+        -s|--scale           <NAME> <NUM>              Set the number of replicas
+        --slowscale          <NAME> <NUM> <TIME>       Scale up to a number of replicas over an amount of time
+                                                       <TIME> is the total time in seconds
+            [-w|--wait]                                Optional: wait for replicas to be available
+
+    * General Options
+
+        -e|--environment     <FNAME>                   Set path to environment.json
+        -k|--kubeconfig      <FNAME>                   'kubeconfig' file path (defaults to value from environment.json)
+
+      * Examples:
+
+      ./k8s-pod-tests -l
+      ./k8s-pod-tests --create default
+
+    Requirements:
+     - 'kubeconfig' file
+     - 'kubectl' executable in path

--- a/k8s-pod-tests/k8s-pod-tests
+++ b/k8s-pod-tests/k8s-pod-tests
@@ -2,10 +2,13 @@
 
 set -euo pipefail
 
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
 # options
 ACTION=""
 WAIT=false
-KUBECONFIG_FN="./kubeconfig"
+ENVIRONMENT=${CAASP_ENVIRONMENT:-$DIR/../caasp-kvm/environment.json}
+KUBECONFIG_FN=
 
 USAGE=$(cat <<USAGE
 Usage:
@@ -29,9 +32,10 @@ Usage:
                                                    <TIME> is the total time in seconds
         [-w|--wait]                                Optional: wait for replicas to be available
 
-  * Options:
+* General Options
 
-    -k|--kubeconfig      <FNAME>                   'kubeconfig' file path (defaults to ./kubeconfig)
+    -e|--environment     <FNAME>                   Set path to environment.json
+    -k|--kubeconfig      <FNAME>                   'kubeconfig' file path (defaults to value from environment.json)
 
   * Examples:
 
@@ -80,6 +84,10 @@ while [[ $# > 0 ]] ; do
       INTERVAL="$4"
       shift
       ;;
+    -e|--environment)
+      ENVIRONMENT="$2"
+      shift
+      ;;
     -k|--kubeconfig)
       KUBECONFIG_FN="$2"
       shift
@@ -94,6 +102,9 @@ while [[ $# > 0 ]] ; do
   esac
   shift
 done
+
+# Determine Kubeconfig path
+KUBECONFIG_FN=${KUBECONFIG_FN:-$(cat $ENVIRONMENT | jq -r ".kubeConfig.admin")}
 
 # Core methods
 

--- a/velum-bootstrap/README.md
+++ b/velum-bootstrap/README.md
@@ -5,6 +5,39 @@ the CaaS platform. They are meant to be run against a CaaSP cluster.
 
 This can be either a production environment installed from images, or a caasp-kvm build cluster.
 
+## CLI Syntax
+
+    Usage:
+
+      * Setup your workstation
+
+        --setup                          Install Dependencies
+
+      * Building a cluster
+
+        -c|--configure                   Configure Velum
+        -b|--bootstrap                   Bootstrap (implies Download Kubeconfig)
+        -k|--download-kubeconfig         Download Kubeconfig
+
+      * Updating a cluster
+
+        -a|--update-admin                Update admin node
+        -m|--update-minions              Update masters and workers
+
+      * General Options
+
+        -e|--environment                 Set path to environment.json
+
+      * Examples:
+
+      Bootstrap a cluster
+
+      ./velum-interactions --configure --bootstrap
+
+      Update a cluster
+
+      ./velum-interactions --update-admin --update-minions
+
 ## Requirements
 
 You can install the necessary dependancy packages with:

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -140,6 +140,12 @@ interact() {
   fi
 
   VERBOSE=true ENVIRONMENT=$ENVIRONMENT bundle exec rspec $args
+
+  if [ "$RUN_DOWNLOAD_KUBECONFIG" = true ]; then
+    local out=$(cat $ENVIRONMENT)
+    out=$(echo "$out" | jq " . + {kubeConfig: {admin: \"$DIR/kubeconfig\"}}")
+    echo "$out" > $ENVIRONMENT
+  fi
 }
 
 # main


### PR DESCRIPTION
* Add kubeconfig path to environment.json when Velum Bootstrap downloads the file
* Update K8S Pod Tests to use kubeconfig path to environment.json by default
* Snuck in an update of the caasp-kvm README.md section CLI syntax