### PR TITLE
Velum Bootstrap: Expect HTTP 200 Status Codes

### DIFF
--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -30,9 +30,11 @@ feature "Boostrap cluster" do
   scenario "User accepts all minions" do
     puts ">>> Waiting 600 seconds as a workaround"
     sleep 600
-    puts ">>> Waiting 600 seconds as a workaround"
+    puts "<<< Waiting 600 seconds as a workaround"
 
-    visit "/setup/discovery"
+    with_status_ok do
+      visit "/setup/discovery"
+    end
 
     puts ">>> Wait until all #{node_number} minions are pending to be accepted"
     with_screenshot(name: :pending_minions) do
@@ -51,10 +53,15 @@ feature "Boostrap cluster" do
       click_button("accept-all")
     end
 
+    puts ">>> Waiting 120 seconds as a workaround"
     # ugly workaround for https://bugzilla.suse.com/show_bug.cgi?id=1050450
     # FIXME: drop it when bug is fixed
     sleep 120
-    visit "/setup/discovery"
+    puts "<<< Waiting 120 seconds as a workaround"
+
+    with_status_ok do
+      visit "/setup/discovery"
+    end
 
     # Min of 240 seconds, Max of 600 seconds, ideal = nodes * 30
     accept_timeout = [[240, node_number * 30].max, 600].min
@@ -77,7 +84,9 @@ feature "Boostrap cluster" do
   end
 
   scenario "User selects minion roles" do
-    visit "/setup/discovery"
+    with_status_ok do
+      visit "/setup/discovery"
+    end
 
     puts ">>> Waiting for page to settle"
     with_screenshot(name: :wait_for_settle) do
@@ -112,7 +121,9 @@ feature "Boostrap cluster" do
   end
 
   scenario "User bootstraps the cluster" do
-    visit "/setup/bootstrap"
+    with_status_ok do
+      visit "/setup/bootstrap"
+    end
 
     puts ">>> Configuring last settings"
     with_screenshot(name: :bootstrap_cluster_settings) do

--- a/velum-bootstrap/spec/features/03-download-kubeconfig.rb
+++ b/velum-bootstrap/spec/features/03-download-kubeconfig.rb
@@ -17,7 +17,9 @@ feature "Download Kubeconfig" do
   end
 
   scenario "User downloads the kubeconfig file" do
-    visit "/"
+    with_status_ok do
+      visit "/"
+    end
 
     expect(page).to have_text("You currently have no nodes to be accepted for bootstrapping", wait: 240)
 

--- a/velum-bootstrap/spec/features/04-upgrade-admin.rb
+++ b/velum-bootstrap/spec/features/04-upgrade-admin.rb
@@ -17,7 +17,9 @@ feature "Upgrade Admin Node" do
   end
 
   scenario "User clicks update admin node" do
-    visit "/"
+    with_status_ok do
+      visit "/"
+    end
 
     puts ">>> Wait for update-admin-node button to be enabled"
     with_screenshot(name: :update_admin_node_button_enabled) do
@@ -49,8 +51,9 @@ feature "Upgrade Admin Node" do
     puts ">>> Wait for Velum to recover"
     1.upto(600) do |n|
       begin
-        visit "/"
-        expect(page.status_code).to be(200)
+        with_status_ok do
+          visit "/"
+        end
         break
       rescue Exception => e
         if n == 600

--- a/velum-bootstrap/spec/features/05-upgrade-minions.rb
+++ b/velum-bootstrap/spec/features/05-upgrade-minions.rb
@@ -17,7 +17,9 @@ feature "update Admin Node" do
   end
 
   scenario "User updates the cluster" do
-    visit "/"
+    with_status_ok do
+      visit "/"
+    end
 
     puts ">>> Wait for update-all-nodes button to be enabled"
     with_screenshot(name: :update_all_nodes_button_enabled) do

--- a/velum-bootstrap/spec/support/helpers.rb
+++ b/velum-bootstrap/spec/support/helpers.rb
@@ -10,11 +10,19 @@ module Helpers
     $counter += 1
   end
 
+  def with_status_ok(&block)
+    yield
+    expect(page.status_code).to eq(200)
+  end
+
   private
 
   def login
     puts ">>> User logs in"
-    visit "/users/sign_in"
+    with_status_ok do
+      visit "/users/sign_in"
+    end
+
     fill_in "user_email", with: "test@test.com"
     fill_in "user_password", with: "password"
     click_on "Log in"
@@ -23,7 +31,10 @@ module Helpers
 
   def register
     puts ">>> Registering user"
-    visit "/users/sign_up"
+    with_status_ok do
+      visit "/users/sign_up"
+    end
+
     fill_in "user_email", with: "test@test.com"
     fill_in "user_password", with: "password"
     fill_in "user_password_confirmation", with: "password"
@@ -41,7 +52,10 @@ module Helpers
 
   def configure
     puts ">>> Setting up velum"
-    visit "/setup"
+    with_status_ok do
+      visit "/setup"
+    end
+
     fill_in "settings_dashboard", with: environment["dashboardHost"] || default_ip_address
     if ENV.fetch("ENABLE_TILLER", false)
       check "settings[tiller]"


### PR DESCRIPTION
If we don't do this, later checks such as this one will hang for the duration
of the wait period:

    expect(page).to have_selector( ..., wait: 400)