### PR TITLE
Make it possible to disable meltdown and spectre patches

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -28,6 +28,7 @@ MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
 IMAGE=${CAASP_IMAGE:-channel://devel}
 VANILLA=${CAASP_VANILLA:-}
+DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-false}
 PROXY=${CAASP_HTTP_PROXY:-}
 PARALLELISM=${CAASP_PARALLELISM:-1}
 ENABLE_TILLER=${CAASP_ENABLE_TILLER:-false}
@@ -47,6 +48,7 @@ DIST_PACKAGES="jq \
                qemu-kvm \
                docker \
                libvirt-daemon-qemu \
+               guestfs-tools \
                ca-certificates-suse"
 
 USAGE=$(cat <<USAGE
@@ -58,13 +60,14 @@ Usage:
 
   * Building a cluster
 
-    -b|--build               Run the CaaSP KVM Build Step
-    -m|--masters <INT>       Number of masters to build (Default: CAASP_NUM_MASTERS)
-    -w|--workers <INT>       Number of workers to build (Default: CAASP_NUM_WORKERS)
-    -d|--destroy             Run the CaaSP KVM Destroy Step
-    -i|--image               Image to use (Default: CAASP_IMAGE)
-    --vanilla                Do not inject devenv code, use vanilla caasp (Default: false)
-    --enable-tiller          Enable Helm Tiller
+    -b|--build                       Run the CaaSP KVM Build Step
+    -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS)
+    -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS)
+    -d|--destroy                     Run the CaaSP KVM Destroy Step
+    -i|--image                       Image to use (Default: CAASP_IMAGE)
+    --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
+    --disable-meltdown-spectre-fixes Disable meltdown and spectre fixes (Default: false)
+    --enable-tiller                  Enable Helm Tiller
 
   * Bootstraping a cluster
 
@@ -132,6 +135,9 @@ while [[ $# > 0 ]] ; do
     --vanilla)
       VANILLA="true"
       ;;
+    --disable-meltdown-spectre-fixes)
+      DISABLE_MELTDOWN_SPECTRE="true"
+      ;;
     --enable-tiller)
       ENABLE_TILLER=true
       ;;
@@ -161,9 +167,10 @@ done
 ##############################################################
 
 CAASP_KVM_ARGS="-m $MASTERS -w $WORKERS --image $IMAGE"
-[ -n "$PARALLELISM" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --parallelism=$PARALLELISM"
-[ -n "$PROXY"       ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --proxy $PROXY"
-[ -n "$VANILLA"     ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --vanilla"
+[ -n "$PARALLELISM"              ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --parallelism=$PARALLELISM"
+[ -n "$PROXY"                    ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --proxy $PROXY"
+[ -n "$VANILLA"                  ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --vanilla"
+[ -n "$DISABLE_MELTDOWN_SPECTRE" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --disable-meltdown-spectre-fixes"
 
 export ENVIRONMENT="$DIR/caasp-kvm/environment.json"
 

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -14,6 +14,7 @@ WORKERS=${CAASP_NUM_WORKERS:-2}
 IMAGE=${CAASP_IMAGE:-channel://devel}
 VELUM_IMAGE=${CAASP_VELUM_IMAGE:-channel://devel}
 VANILLA=${CAASP_VANILLA:-}
+DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-}
 PROXY=${CAASP_HTTP_PROXY:-}
 PARALLELISM=${CAASP_PARALLELISM:-1}
 
@@ -37,12 +38,13 @@ Usage:
 
   * Building a cluster
 
-    -b|--build             Run the CaaSP KVM Build Step
-    -m|--masters <INT>     Number of masters to build (Default: CAASP_NUM_MASTERS=$MASTERS)
-    -w|--workers <INT>     Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
-    -i|--image <STR>       Image to use (Default: CAASP_IMAGE=$IMAGE)
-    --velum-image <STR>    Velum Image to use (Default: CAASP_VELUM_IMAGE=$VELUM_IMAGE)
-    --vanilla              Do not inject devenv code, use vanilla caasp (Default: false)
+    -b|--build                       Run the CaaSP KVM Build Step
+    -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS=$MASTERS)
+    -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
+    -i|--image <STR>                 Image to use (Default: CAASP_IMAGE=$IMAGE)
+    --velum-image <STR>              Velum Image to use (Default: CAASP_VELUM_IMAGE=$VELUM_IMAGE)
+    --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
+    --disable-meltdown-spectre-fixes Disable meltdown and spectre fixes (Default: false)
 
   * Destroying a cluster
 
@@ -117,6 +119,9 @@ while [[ $# > 0 ]] ; do
       ;;
     --vanilla)
       VANILLA="true"
+      ;;
+    --disable-meltdown-spectre-fixes)
+      DISABLE_MELTDOWN_SPECTRE="true"
       ;;
     -p|--parallelism)
       PARALLELISM="$2"
@@ -219,6 +224,11 @@ build() {
   log "Downloading CaaSP KVM Image"
   $DIR/../misc-tools/download-image --proxy "${PROXY}" --type kvm $IMAGE
 
+  if [ -n "$DISABLE_MELTDOWN_SPECTRE" ] ; then
+    log "Preparing artifacts required to disable spectre and meltdown patches"
+    $DIR/../misc-tools/extract-kernel-initrd-cmdline-args --disable-meltdown-spectre --output $DIR/../downloads --report $DIR/../downloads/kernel-initrd-cmds.json $DIR/../downloads/$(basename $IMAGE) || error "Error preparing artifacts required to disable meltdown and spectre"
+  fi
+
   if [ -n "$CAASP_VELUM_DIR" -a "$VANILLA" != "true" ] ; then
     log "Downloading Velum Development Docker Image"
     $DIR/../misc-tools/download-image --proxy "${PROXY}" --type docker --image-name sles12-velum-development $VELUM_IMAGE | tee velum-download.log
@@ -246,10 +256,10 @@ build() {
   fi
 
   log "Generating terraform manifest from erb template"
-  VANILLA=${VANILLA} erb -T - cluster.tf.erb > cluster.tf || error "Failed to generate cluster.tf, check that erb (part of Ruby) is installed correctly"
+  VANILLA=${VANILLA} DISABLE_MELTDOWN_SPECTRE=${DISABLE_MELTDOWN_SPECTRE} erb -T - cluster.tf.erb > cluster.tf || error "Failed to generate cluster.tf, check that erb (part of Ruby) is installed correctly"
 
   log "Applying terraform configuration"
-  terraform init && terraform apply $TF_ARGS
+  terraform init && terraform apply -auto-approve $TF_ARGS
 
   $DIR/tools/generate-environment
   $DIR/../misc-tools/generate-ssh-config $ENVIRONMENT

--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -1,5 +1,9 @@
 <%# This is the embedded ruby template for the cluster.tf target         -%>
 <%# generate the target by running "erb cluster.tf.erb > cluster.tf"     -%>
+<% if ENV['DISABLE_MELTDOWN_SPECTRE'] == "true" -%>
+<% require 'json' -%>
+<% boot_args = JSON.parse(File.read("#{File.dirname(__FILE__)}/../downloads/kernel-initrd-cmds.json")) -%>
+<% end -%>
 #####################
 # libvirt variables #
 #####################
@@ -149,6 +153,17 @@ resource "libvirt_domain" "admin" {
   metadata   = "${var.name_prefix}caasp-admin.${var.caasp_domain_name},admin,${count.index}"
   cloudinit = "${libvirt_cloudinit.admin.id}"
 
+<% if !boot_args.nil? -%>
+  kernel = "<%= boot_args["kernel"] %>"
+  initrd = "<%= boot_args["initrd"] %>"
+
+  cmdline {
+  <% boot_args["args"].each do |k, v| -%>
+    "<%= k %>" = "<%= v %>"
+  <% end -%>
+  }
+<% end -%>
+
   disk {
     volume_id = "${libvirt_volume.admin.id}"
   }
@@ -261,6 +276,17 @@ resource "libvirt_domain" "master" {
   metadata   = "${var.name_prefix}caasp-master-${count.index}.${var.caasp_domain_name},master,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 
+<% if !boot_args.nil? -%>
+  kernel = "<%= boot_args["kernel"] %>"
+  initrd = "<%= boot_args["initrd"] %>"
+
+  cmdline {
+  <% boot_args["args"].each do |k, v| -%>
+    "<%= k %>" = "<%= v %>"
+  <% end -%>
+  }
+<% end -%>
+
   disk {
     volume_id = "${element(libvirt_volume.master.*.id, count.index)}"
   }
@@ -334,6 +360,17 @@ resource "libvirt_domain" "worker" {
   cloudinit  = "${element(libvirt_cloudinit.worker.*.id, count.index)}"
   metadata   = "${var.name_prefix}caasp-worker-${count.index}.${var.caasp_domain_name},worker,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
+
+<% if !boot_args.nil? -%>
+  kernel = "<%= boot_args["kernel"] %>"
+  initrd = "<%= boot_args["initrd"] %>"
+
+  cmdline {
+  <% boot_args["args"].each do |k, v| -%>
+    "<%= k %>" = "<%= v %>"
+  <% end -%>
+  }
+<% end -%>
 
   disk {
     volume_id = "${element(libvirt_volume.worker.*.id, count.index)}"

--- a/misc-tools/extract-kernel-initrd-cmdline-args
+++ b/misc-tools/extract-kernel-initrd-cmdline-args
@@ -1,0 +1,166 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "optparse"
+
+def parse_args
+  options = {
+    disable_meltdown_spectre: false
+  }
+
+  OptionParser.new do |opts|
+    opts.banner = "Usage: extract-kernel-initrd-cmdline-args [options] image"
+
+    opts.on("-o OUTPUT", "--output OUTPUT", "Directory to which extract initrd and kernel") do |o|
+      options[:output] = o
+    end
+
+    opts.on("--report REPORT", "json file holding the information about the run") do |r|
+      options[:report] = r
+    end
+
+    opts.on("--disable-meltdown-spectre", "disable meltdown and spectre fixes") do |d|
+      options[:disable_meltdown_spectre] = d
+    end
+
+  end.parse!
+
+  if ARGV.count != 1
+    puts "Missing name of the qcow2 image to inspect"
+    exit 1
+  end
+
+  options[:image] = ARGV[0]
+
+  if !File.exists?(options[:image])
+    puts "Cannot find file #{options[:image]}"
+    exit 1
+  end
+
+  if options[:output].nil?
+    puts "The --output flag must be specified"
+    exit 1
+  end
+
+  if options[:report].nil?
+    puts "The --report flag must be specified"
+    exit 1
+  end
+
+  return options
+end
+
+def ensure_guestfs_tools_installed
+  if !system("which virt-cat &> /dev/null")
+    puts "guestfs-tools missing, install it via"
+    puts "zypper in guestfs-tools"
+    exit 1
+  end
+end
+
+# Extract /boot/grub.cfg from the qcow file and parses it
+# Returns (kernel, initrd, boot_args)
+def parse_grub_file(image)
+  cmd = "virt-cat -a #{image} /boot/grub2/grub.cfg"
+  puts "Extracting grub.cfg via: #{cmd}"
+  grub = `#{cmd}`
+  if !$?.success?
+    puts "Cannot extract grub.cfg from #{image}: #{grub}"
+  end
+
+  initrd      = ""
+  kernel      = ""
+  boot_args   = ""
+  kernel_line = ""
+
+  grub.each_line do |line|
+    if line =~ /boot\/vmlinuz/
+      # keep the shortest line, needed to avoid the failsafe boot args
+      if kernel_line == "" || line.size < kernel_line.size
+        kernel_line = line
+      end
+    end
+    if line =~ /(\/boot\/initrd-.*-default)/
+      initrd = $1
+    end
+  end
+
+  if kernel_line =~ /(\/boot\/vmlinuz-.*-default) \$\{extra_cmdline\} (.*)/
+    kernel = $1
+    boot_args = $2
+  end
+
+  return kernel, initrd, boot_args
+end
+
+def extracted_filename(name, output_dir)
+  return File.absolute_path(
+    File.join(
+      output_dir,
+      File.basename(name))
+  )
+end
+
+def extract_files(image, output_directory, *files_to_extract)
+  cmd = "virt-copy-out -a #{image} #{files_to_extract.join(" ")} #{output_directory}"
+  puts "Extracting files via #{cmd}"
+  if !system(cmd)
+    puts "error while extracting files from image"
+    exit 1
+  end
+end
+
+def boot_args_to_terraform_format(args, disable_meltdown_spectre)
+  targs = {}
+
+  if disable_meltdown_spectre
+    targs["_"]          = "noptinospec"
+    targs["spectre_v2"] = "off"
+  end
+
+  args.split(" ").each do |arg|
+    if arg.include?("=")
+      res = arg.split("=", 2)
+      targs[res[0]] = res[1]
+    else
+      if targs.has_key?("_")
+        targs["_"] = targs["_"] + " #{arg}"
+      else
+        targs["_"] = arg
+      end
+    end
+  end
+
+  return targs
+end
+
+options = parse_args()
+ensure_guestfs_tools_installed()
+
+kernel_in, initrd_in, boot_args = parse_grub_file(options[:image])
+{"kernel" => kernel_in, "initrd" => initrd_in, "boot args" => boot_args}.each do |k, v|
+  if v == ""
+    puts "Cannot extract #{k} from specified image"
+    exit 1
+  end
+end
+
+
+puts "Extracting kernel and initrd..."
+extract_files(options[:image], options[:output], kernel_in, initrd_in)
+
+kernel_out = extracted_filename(kernel_in, options[:output])
+initrd_out = extracted_filename(initrd_in, options[:output])
+
+data = {
+  kernel: kernel_out,
+  initrd: initrd_out,
+  args: boot_args_to_terraform_format(boot_args, options[:disable_meltdown_spectre]),
+}
+
+
+File.open(options[:report], "w") do |file|
+  file << JSON.generate(data)
+end
+
+puts "Boot related data written to #{options[:report]}"


### PR DESCRIPTION
This commit introduces a new flag that boots all the VMs with the spectre and meltdown fixes disabled.

To do that we have to instruct terraform to boot the VMs with a series of kernel params. We have also to provide libvirt a kernel and an initrd files.

These files, plus the already present kernel boot parameters, are extracted from the qcow image by a new helper tool.

This code requires latest version of terraform-libvirt-provider (I'm working on packaging it).