### PR TITLE
avoid a timeout on IPV6 in wait-for-velum

### DIFF
--- a/misc-tools/wait-for-velum
+++ b/misc-tools/wait-for-velum
@@ -7,6 +7,18 @@ except ImportError:
     raise SystemExit(1)
 import argparse
 import time
+#--------------------
+# this is to force usage of IPV4 even if there are IPV6 addresses (in dns)
+#--------------------
+import socket
+origGetAddrInfo = socket.getaddrinfo
+
+def getAddrInfoWrapper(host, port, family=0, socktype=0, proto=0, flags=0):
+    return origGetAddrInfo(host, port, socket.AF_INET, socktype, proto, flags)
+
+# replace the original socket.getaddrinfo by our version
+socket.getaddrinfo = getAddrInfoWrapper
+#--------------------
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 


### PR DESCRIPTION
This hack makes sure we use IPV4 and do not even try IPV6 to access velum to avoid a 10 second timeout.