### PR TITLE
Purify download file

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -74,6 +74,7 @@ Usage:
     --master-cpu <INT>          RAM to allocate to worker node(s) (Default: CAASP_WORKER_RAM=$WORKER_RAM)
     --worker-cpu <INT>          CPUs to allocate to worker node(s) (Default: CAASP_WORKER_CPU=$WORKER_CPU)
     --extra-repo <STR>          URL of a custom repository on the master(s)/worker(s) (Default: CAASP_EXTRA_REPO)
+    --name-prefix <STR>         Name prefix for the terraform resources to make multiple clusters on one host possible (Default: "")
 
   * Examples:
 

--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -237,7 +237,7 @@ resource "libvirt_domain" "admin" {
 }
 
 output "ip_admin" {
-  value = "${libvirt_domain.admin.network_interface.0.addresses.0}"
+  value = "${libvirt_domain.admin.network_interface.0.addresses[0]}"
 }
 
 ###################
@@ -257,7 +257,7 @@ data "template_file" "master_cloud_init_user_data" {
   template = "${file("cloud-init/master.cfg.tpl")}"
 
   vars {
-    admin_ip = "${libvirt_domain.admin.network_interface.0.addresses.0}"
+    admin_ip = "${libvirt_domain.admin.network_interface.0.addresses[0]}"
   }
 
   depends_on = ["libvirt_domain.admin"]
@@ -326,7 +326,7 @@ resource "libvirt_domain" "master" {
 }
 
 output "masters" {
-  value = ["${libvirt_domain.master.*.network_interface.0.addresses.0}"]
+  value = ["${libvirt_domain.master.*.network_interface.0.addresses[0]}"]
 }
 
 ###################
@@ -346,7 +346,7 @@ data "template_file" "worker_cloud_init_user_data" {
   template = "${file("cloud-init/worker.cfg.tpl")}"
 
   vars {
-    admin_ip = "${libvirt_domain.admin.network_interface.0.addresses.0}"
+    admin_ip = "${libvirt_domain.admin.network_interface.0.addresses[0]}"
   }
 
   depends_on = ["libvirt_domain.admin"]
@@ -415,5 +415,5 @@ resource "libvirt_domain" "worker" {
 }
 
 output "workers" {
-  value = ["${libvirt_domain.worker.*.network_interface.0.addresses.0}"]
+  value = ["${libvirt_domain.worker.*.network_interface.0.addresses[0]}"]
 }

--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -116,7 +116,7 @@ provider "libvirt" {
 
 # This is the CaaSP kvm image that has been created by IBS
 resource "libvirt_volume" "caasp_img" {
-  name   = "${basename(var.caasp_img_source_url)}"
+  name   = "${var.name_prefix}${basename(var.caasp_img_source_url)}"
   source = "../downloads/kvm-${basename(var.caasp_img_source_url)}"
   pool   = "${var.pool}"
 }
@@ -125,9 +125,9 @@ resource "libvirt_volume" "caasp_img" {
 # Networking #
 ##############
 resource "libvirt_network" "network" {
-    name      = "caasp-net"
+    name      = "${var.name_prefix}caasp-net"
     mode      = "${var.caasp_net_mode}"
-    domain    = "${var.caasp_domain_name}"
+    domain    = "${var.name_prefix}${var.caasp_domain_name}"
     addresses = ["${var.caasp_net_network}"]
 }
 

--- a/caasp-kvm/tools/build-velum-image
+++ b/caasp-kvm/tools/build-velum-image
@@ -57,10 +57,10 @@ build_fresh_image() {
                     bash -c "
                       cd /srv/velum-latest && \
                       mkdir -p /var/lib/velum && \
-                      cp -r /srv/velum/vendor/bundle/ruby /var/lib/velum/ && \
-                      bundle config --local frozen 0 && \
-                      bundle config --local build.nokogiri --use-system-libraries && \
-                      bundle install --binstubs=/usr/local/bin --deployment --path=/var/lib/velum && \
+                      gem install --no-ri --no-rdoc bundler -n /usr/bin && \
+                      bundle.ruby2.1 config --local frozen 0 && \
+                      bundle.ruby2.1 config --local build.nokogiri --use-system-libraries && \
+                      bundle.ruby2.1 install --deployment --binstubs=/usr/local/bin --path=/var/lib/velum && \
                       cp Gemfile.lock /var/lib/velum/ && \
                       wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -P /opt && \
                       tar -xjf /opt/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /opt && \

--- a/misc-tools/download-image
+++ b/misc-tools/download-image
@@ -120,6 +120,32 @@ def get_canonical_url(args, url):
     else:
         raise Exception("Cannot find image's real location: " + url)
 
+def get_sha256(url, proxies):
+    print(" >> Downloading Sha256 File")
+    partition = url.rpartition('/')
+    sha256file = requests.head(url + '.sha256', proxies=proxies)
+    
+    if sha256file.status_code == 404:
+        # try to find this file in /SHA256SUMS within the same directory
+        for line in requests.get(partition[0] + "/SHA256SUMS", proxies=proxies).text.split('\n'):
+            # find sha256 for this file
+            columns = line.split(" ")
+            if columns[-1] == partition[2]:
+                if len(columns[0]) == 64:
+                    return columns[0]
+        raise Exception("Cannot find remote image SHA256 in %s" % partition[0] + "/SHA256SUMS")
+    elif sha256file.status_code == 302 or sha256file.status_code == 301:
+        location = sha256file.headers.get('Location')
+        return get_sha256(location[:location.rfind('.sha256')], proxies=proxies)
+    elif sha256file.status_code == 200:
+        # this will work if the SHA256 is stored as a PGP SIGNED MESSAGE in the .sha256 file
+        sha256 = requests.get(url + '.sha256', proxies=proxies).text.split('\n')[3]
+        if len(sha256) == 64:
+            return sha256
+        raise Exception("Cannot find remote image SHA256 in %s" % url + '.sha256')
+    else:
+        raise Exception("Cannot find remote image SHA256")
+
 def download_file(args, canonical_url=None):
     canonical_url = canonical_url or get_canonical_url(args, args.url)
     expected_path = get_expected_path(args)
@@ -136,7 +162,7 @@ def download_file(args, canonical_url=None):
         }
 
         try:
-            remote_sha_pre = requests.get(canonical_url + '.sha256', proxies=proxies).text.split('\n')[3]
+            remote_sha_pre = get_sha256(canonical_url, proxies=proxies)
 
             proxy_flag =  '--no-proxy' if args.proxy == '' else '-e use_proxy=yes -e http_proxy=' + args.proxy
 
@@ -146,7 +172,7 @@ def download_file(args, canonical_url=None):
             )
 
             local_sha = os.popen('sha256sum %s' % actual_path).read().split(' ')[0]
-            remote_sha_post = requests.get(canonical_url + '.sha256', proxies=proxies).text.split('\n')[3]
+            remote_sha_post = get_sha256(canonical_url, proxies=proxies)
 
             print(" >> Local SHA:                  %s" % local_sha)
             print(" >> Remote SHA (Pre Download):  %s" % remote_sha_pre)

--- a/misc-tools/download-image
+++ b/misc-tools/download-image
@@ -147,13 +147,13 @@ def get_sha256(url, proxies):
         raise Exception("Cannot find remote image SHA256")
 
 def download_file(args, canonical_url=None):
-    canonical_url = canonical_url or get_canonical_url(args, args.url)
+    url = canonical_url or args.url
     expected_path = get_expected_path(args)
-    actual_path = get_actual_path(args, canonical_url)
+    actual_path = get_actual_path(args, url)
 
     if not os.path.isfile(actual_path):
         print(" >> Downloading File")
-        print(" >> Remote File         : " + canonical_url)
+        print(" >> Remote File         : " + url)
         print(" >> Local File (On Disk): " + actual_path)
 
         proxies = {
@@ -162,17 +162,17 @@ def download_file(args, canonical_url=None):
         }
 
         try:
-            remote_sha_pre = get_sha256(canonical_url, proxies=proxies)
+            remote_sha_pre = get_sha256(url, proxies=proxies)
 
             proxy_flag =  '--no-proxy' if args.proxy == '' else '-e use_proxy=yes -e http_proxy=' + args.proxy
 
             os.system(
                 "wget %(proxy_flag)s %(url)s -O %(file)s --progress=dot:giga" %
-                { "url": canonical_url, "file": actual_path, "proxy_flag": proxy_flag}
+                { "url": url, "file": actual_path, "proxy_flag": proxy_flag}
             )
 
             local_sha = os.popen('sha256sum %s' % actual_path).read().split(' ')[0]
-            remote_sha_post = get_sha256(canonical_url, proxies=proxies)
+            remote_sha_post = get_sha256(url, proxies=proxies)
 
             print(" >> Local SHA:                  %s" % local_sha)
             print(" >> Remote SHA (Pre Download):  %s" % remote_sha_pre)

--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -134,8 +134,8 @@ feature "Boostrap cluster" do
       click_on "Bootstrap cluster"
     end
 
-    # Min of 1800 seconds, Max of 7200 seconds, ideal = nodes * 120 seconds
-    orchestration_timeout = [[1800, node_number * 120].max, 7200].min
+    # Min of 3600 seconds, Max of 7200 seconds, ideal = nodes * 120 seconds
+    orchestration_timeout = [[3600, node_number * 120].max, 7200].min
     puts ">>> Wait until orchestration is complete (Timeout: #{orchestration_timeout})"
     with_screenshot(name: :orchestration_complete) do
       within(".nodes-container") do

--- a/velum-bootstrap/spec/features/05-upgrade-minions.rb
+++ b/velum-bootstrap/spec/features/05-upgrade-minions.rb
@@ -42,8 +42,8 @@ feature "update Admin Node" do
     # Allow 10 seconds for Velum to re-render nodes with spinners
     sleep 10
 
-    # Min of 1800 seconds, Max of 7200 seconds, ideal = nodes * 120 seconds
-    update_timeout = [[1800, node_number * 120].max, 7200].min
+    # Min of 3600 seconds, Max of 7200 seconds, ideal = nodes * 120 seconds
+    update_timeout = [[3600, node_number * 120].max, 7200].min
     puts ">>> Wait until update is complete (Timeout: #{update_timeout})"
     with_screenshot(name: :update_complete) do
       within(".nodes-container") do

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -28,7 +28,7 @@ end
 Capybara.register_driver :poltergeist do |app|
   options = {
     timeout:           180,
-    js_errors:         false,
+    js_errors:         true,
     phantomjs_options: [
       "--proxy-type=none",
       "--load-images=yes"

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -86,8 +86,8 @@ RSpec.configure do |config|
   # fail fast
   config.fail_fast = true
 
-  # Set a timeout around the tests
-  timeout = ENV.fetch('TEST_TIMEOUT', 2200).to_i
+  # Set a fallback timeout around the tests
+  timeout = ENV.fetch('TEST_TIMEOUT', 7200).to_i
 
   config.around(:each) do |test|
     begin


### PR DESCRIPTION
This change will make the use of local copies of remote URL images possible even if the remote image is gone.

It will make download_file stop trying to make the given url from args canonical. 
By that we avoid the http head request in make_canonical that would fail if there is no remote file (anymore). We would not even try to download the image anyway if a local copy of the same name is there. 
Beside that, making the url canonical is not needed anyway because we use wget to download and that tool takes care of redirects.

I hope that #286 will get merged, after that I'll rebase this to get it in.
