### PR TITLE
Do not copy gems from the packaging side as they contain invalid symlinks

### DIFF
--- a/caasp-kvm/tools/build-velum-image
+++ b/caasp-kvm/tools/build-velum-image
@@ -57,10 +57,10 @@ build_fresh_image() {
                     bash -c "
                       cd /srv/velum-latest && \
                       mkdir -p /var/lib/velum && \
-                      cp -r /srv/velum/vendor/bundle/ruby /var/lib/velum/ && \
-                      bundle config --local frozen 0 && \
-                      bundle config --local build.nokogiri --use-system-libraries && \
-                      bundle install --binstubs=/usr/local/bin --deployment --path=/var/lib/velum && \
+                      gem install --no-ri --no-rdoc bundler -n /usr/bin && \
+                      bundle.ruby2.1 config --local frozen 0 && \
+                      bundle.ruby2.1 config --local build.nokogiri --use-system-libraries && \
+                      bundle.ruby2.1 install --deployment --binstubs=/usr/local/bin --path=/var/lib/velum && \
                       cp Gemfile.lock /var/lib/velum/ && \
                       wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -P /opt && \
                       tar -xjf /opt/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /opt && \


### PR DESCRIPTION
In any case we are downloading gems from the outside (rubygems) because the
development gems are not included with the Velum package, so don't copy
gems back to development image.

Fixes the fontawesome problem.