### PR TITLE
enable adding/removing nodes through caasp-kvm and velum-interactions

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -20,6 +20,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 # options
 RUN_SETUP=
 RUN_BUILD=
+RUN_UPDATE_DEPLOYMENT=
 RUN_BOOTSTRAP=
 RUN_TESTINFRA=
 RUN_DESTROY=
@@ -65,6 +66,7 @@ Usage:
     -b|--build                       Run the CaaSP KVM Build Step
     -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS)
     -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS)
+    -u|--update-deployment           Update Terraform deployment (Default: false)
     -d|--destroy                     Run the CaaSP KVM Destroy Step
     -i|--image                       Image to use (Default: CAASP_IMAGE)
     --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
@@ -100,6 +102,10 @@ Usage:
   Bootstrap and Test a pre-made cluster
 
   $0 --bootstrap --testinfra
+
+  Add a worker node to a running cluster
+
+  $0 --update-deployment -m 1 -w 3
 
   Build a cluster and add a custom repository on the master/worker(s)
 
@@ -137,6 +143,10 @@ while [[ $# > 0 ]] ; do
     -d|--destroy)
       ACTION=1
       RUN_DESTROY=1
+      ;;
+    -u|--update-deployment)
+      ACTION=1
+      RUN_UPDATE_DEPLOYMENT=1
       ;;
     -i|--image)
       IMAGE="$2"
@@ -226,6 +236,11 @@ build() {
   (cd "$DIR/caasp-kvm" && ./caasp-kvm --build $CAASP_KVM_ARGS )
 }
 
+update_deployment() {
+  log "Updating CaaSP KVM Environment"
+  (cd "$DIR/caasp-kvm" && ./caasp-kvm --update-deployment $CAASP_KVM_ARGS )
+}
+
 bootstrap() {
   log "Bootstrap CaaSP Environment"
 
@@ -249,9 +264,10 @@ destroy() {
   (cd "$DIR/caasp-kvm" && ./caasp-kvm --destroy $CAASP_KVM_ARGS)
 }
 
-[ -n "$ACTION"        ] || usage
-[ -n "$RUN_SETUP"     ] && setup
-[ -n "$RUN_BUILD"     ] && build
+[ -n "$ACTION" ] || usage
+[ -n "$RUN_SETUP" ] && setup
+[ -n "$RUN_BUILD" -a -z "$RUN_UPDATE_DEPLOYMENT" ] && build
+[ -n "$RUN_UPDATE_DEPLOYMENT" ] && update_deployment
 [ -n "$RUN_BOOTSTRAP" ] && bootstrap
 [ -n "$RUN_TESTINFRA" ] && testinfra
-[ -n "$RUN_DESTROY"   ] && destroy
+[ -n "$RUN_DESTROY" ] && destroy

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -8,6 +8,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 ACTION=
 RUN_BUILD=
 RUN_DESTROY=
+RUN_UPDATE_DEPLOYMENT=
 
 MASTERS=${CAASP_NUM_MASTERS:-1}
 WORKERS=${CAASP_NUM_WORKERS:-2}
@@ -44,6 +45,7 @@ Usage:
     -b|--build                       Run the CaaSP KVM Build Step
     -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS=$MASTERS)
     -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
+    -u|--update-deployment           Update Terraform deployment (Default: false)
     -i|--image <STR>                 Image to use (Default: CAASP_IMAGE=$IMAGE)
     --velum-image <STR>              Velum Image to use (Default: CAASP_VELUM_IMAGE=$VELUM_IMAGE)
     --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
@@ -89,6 +91,10 @@ Usage:
   Build a 1 master, 2 worker cluster and add a custom repository on the master(s)/worker(s)
 
   $0 --build -m 1 -w 2 --extra-repo https://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode:/TestUpdates
+
+  Add a worker node to a running cluster
+
+  $0 --update-deployment -m 1 -w 3
 
   Destroy a cluster
 
@@ -148,6 +154,10 @@ while [[ $# > 0 ]] ; do
     -d|--destroy)
       ACTION=1
       RUN_DESTROY=1
+      ;;
+    -u|--update-deployment)
+      ACTION=1
+      RUN_UPDATE_DEPLOYMENT=1
       ;;
     --salt-dir)
       CAASP_SALT_DIR="$2"
@@ -273,11 +283,7 @@ build() {
   log "Generating terraform manifest from erb template"
   VANILLA=${VANILLA} DISABLE_MELTDOWN_SPECTRE=${DISABLE_MELTDOWN_SPECTRE} erb -T - cluster.tf.erb > cluster.tf || error "Failed to generate cluster.tf, check that erb (part of Ruby) is installed correctly"
 
-  log "Applying terraform configuration"
-  terraform init && terraform apply -auto-approve $TF_ARGS
-
-  $DIR/tools/generate-environment
-  $DIR/../misc-tools/generate-ssh-config $ENVIRONMENT
+  update_deployment
 
   [ -n "$EXTRA_REPO" ] && $DIR/../misc-tools/inject_repo.sh $EXTRA_REPO
 
@@ -287,6 +293,14 @@ build() {
   log "CaaS Platform Ready for bootstrap"
 }
 
+update_deployment() {
+  log "Applying terraform configuration"
+  terraform init && terraform apply -auto-approve $TF_ARGS
+
+  $DIR/tools/generate-environment
+  $DIR/../misc-tools/generate-ssh-config $ENVIRONMENT
+}
+
 destroy() {
   log "Destroying terraform configuration"
   terraform init && \
@@ -294,8 +308,9 @@ destroy() {
     rm -f "$ENVIRONMENT"
 }
 
-[ -n "$ACTION"      ] || usage
-[ -n "$RUN_BUILD"   ] && build
+[ -n "$ACTION" ] || usage
+[ -n "$RUN_BUILD" -a -z "$RUN_UPDATE_DEPLOYMENT" ] && build
+[ -n "$RUN_UPDATE_DEPLOYMENT" ] && update_deployment
 [ -n "$RUN_DESTROY" ] && destroy
 
 exit 0

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
@@ -1,0 +1,34 @@
+def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubic
+
+// Configure the build properties
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('@daily')])
+])
+
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.vanilla = true
+
+coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions
+) {
+    // empty preBootstrapBody
+} {
+    // create another worker node
+    updateEnvironmentCaaspKvm(
+        environment: environment,
+        masterCount: 3,
+        workerCount: 3
+    )
+    // register it via velum
+    bootstrapNewNode(
+        environment: environment
+    )
+} {
+    // Run the Core Project Tests again
+    coreKubicProjectTests(
+        environment: environment,
+        podName: 'default'
+    )
+}

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-remove
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-remove
@@ -1,0 +1,28 @@
+def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubic
+
+// Configure the build properties
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('@daily')])
+])
+
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.vanilla = true
+
+coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions
+) {
+    // empty preBootstrapBody
+} {
+    // register it via velum
+    removeNode(
+        environment: environment
+    )
+} {
+    // Run the Core Project Tests again
+    coreKubicProjectTests(
+        environment: environment,
+        podName: 'default'
+    )
+}

--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require 'yaml'
+require "yaml"
 
 feature "Boostrap cluster" do
 
@@ -144,7 +144,7 @@ feature "Boostrap cluster" do
     end
     puts "<<< Orchestration completed"
 
-    puts ">>> Orchestration succeeded"
+    puts ">>> Checking if orchestration succeeded"
     with_screenshot(name: :orchestration_succeeded) do
       within(".nodes-container") do
         expect(page).to have_css(".fa-check-circle-o", count: node_number, wait: 5)

--- a/velum-bootstrap/spec/features/06-node-add.rb
+++ b/velum-bootstrap/spec/features/06-node-add.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+require "yaml"
+
+feature "Add a Node" do
+
+  before(:each) do
+    login
+  end
+
+  # Using append after in place of after, as recommended by
+  # https://github.com/mattheworiordan/capybara-screenshot#common-problems
+  append_after(:each) do
+    Capybara.reset_sessions!
+  end
+
+  scenario "User accepts new nodes" do
+    with_status_ok do
+      visit "/"
+    end
+
+    puts ">>> Checking if new nodes appeared"
+    with_screenshot(name: :new_nodes_appearance) do
+      within(".pending-nodes-container") do
+        expect(page).to have_button("accept-all", wait: 120)
+      end
+    end
+    puts "<<< New nodes have appeared"
+
+    puts ">>> Click to accept all minion keys"
+    with_screenshot(name: :accept_button_click) do
+      click_button("accept-all")
+    end
+
+    puts ">>> Waiting 120 seconds as a workaround"
+    # ugly workaround for https://bugzilla.suse.com/show_bug.cgi?id=1050450
+    # FIXME: drop it when bug is fixed
+    sleep 120
+    puts "<<< Waiting 120 seconds as a workaround"
+
+    # wait for new link to appear
+    puts ">>> Wait for new-node link to be enabled"
+    with_screenshot(name: :new_node_link_enabled) do
+      expect(page).to have_link(class: "assign-nodes-link", wait: 120)
+    end
+    puts "<<< new node link enabled"
+
+    with_status_ok do
+      visit "/assign_nodes"
+    end
+
+    puts ">>> Waiting for page to settle"
+    with_screenshot(name: :wait_for_settle_new_nodes) do
+      expect(page).not_to have_text("Loading...", wait: 20)
+    end
+    puts "<<< Page has settled"
+
+    new_nodes_count = environment["minions"].count
+    puts ">>> Selecting minion roles"
+    with_screenshot(name: :select_new_minion_roles) do
+      environment["minions"].each do |minion|
+        # skip all minions that have been assigned already
+        unless page.text.include? minion["minionID"]
+          new_nodes_count -= 1
+          next
+        end
+        if ["master", "worker"].include?(minion["role"])
+          within("tr", text: minion["minionId"] || minion["minionID"]) do
+            find(".#{minion["role"]}-btn").click
+          end
+        end
+      end
+    end
+
+    puts ">>> Wait for Add nodes button to be enabled"
+    with_screenshot(name: :add_nodes_button_enabled) do
+      expect(page).to have_css(".add-nodes-btn", wait: 20)
+    end
+    puts "<<< Add nodes button enabled"
+
+    puts ">>> click to add node"
+    with_screenshot(name: :select_new_nodes_role) do
+      find(".add-nodes-btn").click
+    end
+    puts "<<< clicked add node"
+
+    orchestration_timeout = [[3600, new_nodes_count * 120].max, 7200].min
+    puts ">>> Wait until node add orchestration is complete (Timeout: #{orchestration_timeout})"
+    with_screenshot(name: :node_add_orchestration_complete) do
+      within(".nodes-container") do
+        expect(page).to have_css(".fa-check-circle-o, .fa-times-circle", count: new_nodes_count, wait: orchestration_timeout)
+      end
+    end
+    puts "<<< Node add orchestration completed"
+
+    puts ">>> Checking if node add orchestration succeeded"
+    with_screenshot(name: :node_add_orchestration_succeeded) do
+      within(".nodes-container") do
+        expect(page).to have_css(".fa-check-circle-o", count: new_nodes_count, wait: 5)
+      end
+    end
+    puts "<<< Node add orchestration succeeded"
+  end
+end

--- a/velum-bootstrap/spec/features/07-node-remove.rb
+++ b/velum-bootstrap/spec/features/07-node-remove.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "yaml"
+
+feature "Remove a Node" do
+
+  let(:node_number) { environment["minions"].count { |element| element["role"] != "admin" } }
+  let(:worker_number) { environment["minions"].count { |element| element["role"] == "worker" } }
+
+  before(:each) do
+    login
+  end
+
+  # Using append after in place of after, as recommended by
+  # https://github.com/mattheworiordan/capybara-screenshot#common-problems
+  append_after(:each) do
+    Capybara.reset_sessions!
+  end
+
+  scenario "User removes a node" do
+    with_status_ok do
+      visit "/"
+    end
+
+    puts ">>> Checking if node can be removed"
+    with_screenshot(name: :node_removable) do
+      within(".nodes-container") do
+        expect(page).to have_link(text: "Remove", count: worker_number, wait: 120)
+      end
+    end
+    puts "<<< A node can be removed"
+
+    puts ">>> Click to remove a node"
+    with_screenshot(name: :node_removal) do
+      first(".remove-node-link").click
+    end
+
+    orchestration_timeout = [[3600, 120].max, 7200].min
+    puts ">>> Waiting for node removal"
+    with_screenshot(name: :wait_node_removal) do
+      within(".nodes-container") do
+        expect(page).to have_css(".fa-check-circle-o, .fa-times-circle", count: 1, wait: orchestration_timeout)
+      end
+    end
+    puts "<<< node removal finished"
+
+    puts ">>> Checking if node removal orchestration succeeded"
+    with_screenshot(name: :node_removal_orchestration_succeeded) do
+      within(".nodes-container") do
+        expect(page).to have_css(".fa-check-circle-o", count: node_number-1, wait: 5)
+      end
+    end
+    puts "<<< Node removal orchestration succeeded"
+  end
+end

--- a/velum-bootstrap/spec/support/helpers.rb
+++ b/velum-bootstrap/spec/support/helpers.rb
@@ -57,7 +57,7 @@ module Helpers
     end
 
     fill_in "settings_dashboard", with: environment["dashboardHost"] || default_ip_address
-    if ENV.fetch("ENABLE_TILLER", false)
+    if ENV.fetch("ENABLE_TILLER", false) == "true"
       check "settings[tiller]"
     else
       uncheck "settings[tiller]"

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -14,6 +14,7 @@ RUN_DOWNLOAD_KUBECONFIG=false
 RUN_UPDATE_ADMIN=false
 RUN_UPDATE_MINIONS=false
 RUN_NODE_ADD=false
+RUN_NODE_REMOVE=false
 ENABLE_TILLER=false
 
 ENVIRONMENT=${CAASP_ENVIRONMENT:-$DIR/../caasp-kvm/environment.json}
@@ -40,6 +41,7 @@ Usage:
   * Manipulating a cluster
 
     --node-add                       Accepts and bootstraps a node after the initial bootstrap
+    --node-remove                    Removes a node after the initial bootstrap
 
   * General Options
 
@@ -105,6 +107,11 @@ while [[ $# > 0 ]] ; do
       HAS_INTERACTION=true
       HAS_ACTION=true
       ;;
+    --node-remove)
+      RUN_NODE_REMOVE=true
+      HAS_INTERACTION=true
+      HAS_ACTION=true
+      ;;
     -e|--environment)
       ENVIRONMENT="$2"
       shift
@@ -156,6 +163,10 @@ interact() {
 
   if [ "$RUN_NODE_ADD" = true ]; then
     args="$args spec/**/06-*"
+  fi
+
+  if [ "$RUN_NODE_REMOVE" = true ]; then
+    args="$args spec/**/07-*"
   fi
 
   VERBOSE=true ENABLE_TILLER=${ENABLE_TILLER} ENVIRONMENT=$ENVIRONMENT bundle exec rspec $args

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -13,6 +13,7 @@ RUN_BOOTSTRAP=false
 RUN_DOWNLOAD_KUBECONFIG=false
 RUN_UPDATE_ADMIN=false
 RUN_UPDATE_MINIONS=false
+RUN_NODE_ADD=false
 ENABLE_TILLER=false
 
 ENVIRONMENT=${CAASP_ENVIRONMENT:-$DIR/../caasp-kvm/environment.json}
@@ -35,6 +36,10 @@ Usage:
 
     -a|--update-admin                Update admin node
     -m|--update-minions              Update masters and workers
+
+  * Manipulating a cluster
+
+    --node-add                       Accepts and bootstraps a node after the initial bootstrap
 
   * General Options
 
@@ -95,6 +100,11 @@ while [[ $# > 0 ]] ; do
       HAS_INTERACTION=true
       HAS_ACTION=true
       ;;
+    --node-add)
+      RUN_NODE_ADD=true
+      HAS_INTERACTION=true
+      HAS_ACTION=true
+      ;;
     -e|--environment)
       ENVIRONMENT="$2"
       shift
@@ -142,6 +152,10 @@ interact() {
 
   if [ "$RUN_UPDATE_MINIONS" = true ]; then
     args="$args spec/**/05-*"
+  fi
+
+  if [ "$RUN_NODE_ADD" = true ]; then
+    args="$args spec/**/06-*"
   fi
 
   VERBOSE=true ENABLE_TILLER=${ENABLE_TILLER} ENVIRONMENT=$ENVIRONMENT bundle exec rspec $args


### PR DESCRIPTION
Signed-off-by: Maximilian Meister <mmeister@suse.de>

## how to test

```
# spawn and bootstrap cluster
./caasp-devenv --build -m 1 -w 1 --bootstrap
# let terraform add another node
./caasp-devenv --update-deployment -m 1 -w 2
# run ui automation to add the node
./velum-interactions --node-add
# run ui automation to remove a node
./velum-interactions --node-remove
```

### nightly pipelines depend on:

https://github.com/kubic-project/jenkins-library/pull/151