### PR TITLE
use unix time instead of self made counter

### DIFF
--- a/velum-bootstrap/spec/support/helpers.rb
+++ b/velum-bootstrap/spec/support/helpers.rb
@@ -2,12 +2,9 @@
 # for end to end tests.
 module Helpers
   def with_screenshot(name:, &block)
-    $counter ||= 0
-    formatted_counter = format('%02d', $counter)
-    save_screenshot("screenshots/#{formatted_counter}_before_#{name}.png", full: true)
+    save_screenshot("screenshots/#{Time.now.to_i}_before_#{name}.png", full: true)
     yield
-    save_screenshot("screenshots/#{formatted_counter}_after_#{name}.png", full: true)
-    $counter += 1
+    save_screenshot("screenshots/#{Time.now.to_i}_after_#{name}.png", full: true)
   end
 
   def with_status_ok(&block)


### PR DESCRIPTION
the goal was originally to have an ascending numeration for the
screenshots in the jenkins UI

but the counter only works when the whole testsuite is ran in 1
single file

in the meantime jobs got split into different files, so the counter
is reset, which renders it's purpose useless

Signed-off-by: Maximilian Meister <mmeister@suse.de>