### PR TITLE
master nodes are removable now as well

### DIFF
--- a/velum-bootstrap/spec/features/07-node-remove.rb
+++ b/velum-bootstrap/spec/features/07-node-remove.rb
@@ -4,7 +4,6 @@ require "yaml"
 feature "Remove a Node" do
 
   let(:node_number) { environment["minions"].count { |element| element["role"] != "admin" } }
-  let(:worker_number) { environment["minions"].count { |element| element["role"] == "worker" } }
 
   before(:each) do
     login
@@ -24,7 +23,7 @@ feature "Remove a Node" do
     puts ">>> Checking if node can be removed"
     with_screenshot(name: :node_removable) do
       within(".nodes-container") do
-        expect(page).to have_link(text: "Remove", count: worker_number, wait: 120)
+        expect(page).to have_link(text: "Remove", count: node_number, wait: 120)
       end
     end
     puts "<<< A node can be removed"


### PR DESCRIPTION
5 node nightly ci failed because it found 5 nodes to remove

Signed-off-by: Maximilian Meister <mmeister@suse.de>

from http://jenkins.caasp.suse.net/job/caasp-nightly-node-remove/job/master/7/consoleFull

```
>>> Checking if node can be removed
  User removes a node (FAILED - 1)

Failures:

  1) Remove a Node User removes a node
     Failure/Error: expect(page).to have_link(text: "Remove", count: worker_number, wait: 120)
       expected to find link nil with text "Remove" 2 times, found 5 matches: "Remove", "Remove", "Remove", "Remove", "Remove". Also found "kubectl config", "", "", which matched the selector but not all filters.
```

**cc** @vitoravelino can you confirm that masters are also removable now?