### PR TITLE
[2.0] Add empty preBootstrapBody to all periodic jenkinsfiles

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
@@ -11,6 +11,8 @@ properties([
 // method signature which contains the closure. Unsure why at the
 // moment.
 coreKubicProjectPeriodic(foo: "bar") {
+    // empty preBootstrapBody
+} {
     stage('Run K8S Conformance Tests') {
         runTestK8sConformance(environment: environment)
     }

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly
@@ -13,6 +13,8 @@ kvmTypeOptions.vanilla = true
 coreKubicProjectPeriodic(
     environmentTypeOptions: kvmTypeOptions
 ) {
+    // empty preBootstrapBody
+} {
     // Run through the upgrade orchestration
     upgradeEnvironment(
         environment: environment,

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
@@ -20,6 +20,8 @@ coreKubicProjectPeriodic(
     masterCount: env.MASTER_COUNT.toInteger(),
     workerCount: env.WORKER_COUNT.toInteger()
 ) {
+    // empty preBootstrapBody
+} {
     // Run through the upgrade orchestration
     upgradeEnvironment(
         environment: environment,

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
@@ -32,6 +32,8 @@ lock('openstack-single-user') {
         masterCount: env.MASTER_COUNT.toInteger(),
         workerCount: env.WORKER_COUNT.toInteger()
     ) {
+        // empty preBootstrapBody
+    } {
         // Run through the upgrade orchestration
         upgradeEnvironment(
             environment: environment,

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -13,6 +13,8 @@ kvmTypeOptions.vanilla = true
 coreKubicProjectPeriodic(
     environmentTypeOptions: kvmTypeOptions
 ) {
+    // empty preBootstrapBody
+} {
     // Install Update Repo
     prepareUpgradeEnvironment(
         environment: environment,


### PR DESCRIPTION
Without this, it seems it wasn't running any of the job specific steps :(

Backport of https://github.com/kubic-project/automation/pull/315