### PR TITLE
Allow status to be passed to Testinfra

### DIFF
--- a/testinfra/tox.ini
+++ b/testinfra/tox.ini
@@ -12,19 +12,64 @@ envdir={toxworkdir}/kubic-testinfra
 passenv=ENVIRONMENT_JSON
 
 [testenv:admin]
-commands = 
+# TODO: Remove once https://github.com/kubic-project/jenkins-library/pull/159 merges
+commands =
     pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "admin or common" -v {posargs}
 
 [testenv:master]
-commands = 
+# TODO: Remove once https://github.com/kubic-project/jenkins-library/pull/159 merges
+commands =
     pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "master or common" -v {posargs}
 
 [testenv:worker]
-commands = 
+# TODO: Remove once https://github.com/kubic-project/jenkins-library/pull/159 merges
+commands =
     pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "worker or common" -v {posargs}
 
+[testenv:admin-bootstrapped]
+commands =
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "admin or common" -v {posargs}
+
+[testenv:admin-unused]
+# TODO: Test that nothing is running...
+commands =
+    /bin/true
+
+[testenv:admin-removed]
+# TODO: Test that nothing is running...
+commands =
+    /bin/true
+
+[testenv:master-bootstrapped]
+commands =
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "master or common" -v {posargs}
+
+[testenv:master-unused]
+# TODO: Test that nothing is running...
+commands =
+    /bin/true
+
+[testenv:master-removed]
+# TODO: Test that nothing is running...
+commands =
+    /bin/true
+
+[testenv:worker-bootstrapped]
+commands =
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "worker or common" -v {posargs}
+
+[testenv:worker-unused]
+# TODO: Test that nothing is running...
+commands =
+    /bin/true
+
+[testenv:worker-removed]
+# TODO: Test that nothing is running...
+commands =
+    /bin/true
+
 [testenv:all]
-commands = 
+commands =
     sh {toxinidir}/tools/testAllRoles.sh {env:ENVIRONMENT_JSON:{toxinidir}/../caasp-kvm/environment.json} {env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} {posargs}
 
 [testenv:linters]


### PR DESCRIPTION
This allows for testing with unused/removed/etc minions. New status
types are stubbed out.