### PR TITLE
K8S Conformance Jobs: Use caasp-kvm in 'vanilla' mode

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
@@ -1,4 +1,4 @@
-library "kubic-jenkins-library@${env.BRANCH_NAME}"
+def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubic
 
 // Configure the build properties
 properties([
@@ -7,10 +7,12 @@ properties([
     pipelineTriggers([cron('@daily')]),
 ])
 
-// Without at least one argument, Jenkins fails to find a matching
-// method signature which contains the closure. Unsure why at the
-// moment.
-coreKubicProjectPeriodic(foo: "bar") {
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.vanilla = true
+
+coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions
+) {
     // empty preBootstrapBody
 } {
     stage('Run K8S Conformance Tests') {


### PR DESCRIPTION
For conformance test jobs, we don't want to inject the latest code
from git, vanilla mode prevents this.