### PR TITLE
caasp prefix has been removed from metadata

### DIFF
--- a/caasp-kvm/cloud-init/admin.cfg
+++ b/caasp-kvm/cloud-init/admin.cfg
@@ -7,8 +7,8 @@ locale: en_GB.UTF-8
 timezone: Etc/UTC
 
 # Set hostname and FQDN
-hostname: caasp-admin
-fqdn: caasp-admin.devenv.caasp.suse.net
+hostname: admin
+fqdn: admin.devenv.caasp.suse.net
 
 # set root password
 chpasswd:

--- a/caasp-kvm/cloud-init/master.cfg.tpl
+++ b/caasp-kvm/cloud-init/master.cfg.tpl
@@ -8,8 +8,8 @@ timezone: Etc/UTC
 
 # Set hostname and FQDN
 # TODO: We only generate 1 cloud-init, so can't include the index here?
-#hostname: caasp-master-INDEX-HERE
-#fqdn: caasp-master-INDEX-HERE.devenv.caasp.suse.net
+#hostname: master-INDEX-HERE
+#fqdn: master-INDEX-HERE.devenv.caasp.suse.net
 
 # set root password
 chpasswd:

--- a/caasp-kvm/cloud-init/worker.cfg.tpl
+++ b/caasp-kvm/cloud-init/worker.cfg.tpl
@@ -8,8 +8,8 @@ timezone: Etc/UTC
 
 # Set hostname and FQDN
 # TODO: We only generate 1 cloud-init, so can't include the index here?
-#hostname: caasp-worker-INDEX-HERE
-#fqdn: caasp-worker-INDEX-HERE.devenv.caasp.suse.net
+#hostname: worker-INDEX-HERE
+#fqdn: worker-INDEX-HERE.devenv.caasp.suse.net
 
 # set root password
 chpasswd:


### PR DESCRIPTION
update hostnames in cloud-init

Signed-off-by: Maximilian Meister <mmeister@suse.de>


relevant commit: 

https://github.com/kubic-project/automation/commit/e5eac687760a33267048364d778c2e8531c4d9f9