### PR TITLE
KVM: Fix parallelism flag

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -243,7 +243,7 @@ EOF
   exit 1
 fi
 
-TF_ARGS="-var parallelism=$PARALLELISM \
+TF_ARGS="-parallelism=$PARALLELISM \
          -var img_source_url=$IMAGE \
          -var master_count=$MASTERS \
          -var worker_count=$WORKERS \


### PR DESCRIPTION
This was accidently changed from a ordinary argument to a variable in
c841dc225ea7d248ae99a1cb121b0b1580c774b9.