### PR TITLE
Schedule all nightly jobs between 3 and 5am UTC

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kube-conformance-nightly
@@ -4,7 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')]),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly
@@ -4,7 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')]),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
@@ -4,7 +4,7 @@ library "kubic-jenkins-library@${env.BRANCH_NAME}"
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')]),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
     parameters([
         string(name: 'MASTER_COUNT', defaultValue: '1', description: 'Number of Master Nodes'),
         string(name: 'WORKER_COUNT', defaultValue: '3', description: 'Number of Worker Nodes'),

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
@@ -4,7 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')])
+    pipelineTriggers([cron('H H(3-5) * * *')])
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-remove
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-remove
@@ -4,7 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')])
+    pipelineTriggers([cron('H H(3-5) * * *')])
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
@@ -4,7 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')]),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
     parameters([
         string(name: 'OPENSTACK_IMAGE', defaultValue: '', description: 'OpenStack Image To Use'),
         string(name: 'MASTER_COUNT', defaultValue: '3', description: 'Number of Master Nodes'),

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -4,7 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('@daily')]),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();


### PR DESCRIPTION
This will help ensure periodic jobs are running when the CI system
is otherwise idle outside of EU / US working hours.