### PR TITLE
patch image paths when using kubic

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -234,6 +234,7 @@ done
 if [[ $IMAGE =~ [Kk]ubic ]]; then
   VELUM_IMAGE=channel://kubic
   DIST=kubic
+  KUBIC_MANIFEST_FLAG="--kubic"
 # check if internal network is reachable and fail early
 elif ! ping -q -c1 download.suse.de 2>&1 >/dev/null; then
   cat <<EOF
@@ -310,7 +311,12 @@ build() {
     cp -r $CAASP_MANIFESTS_DIR/* "$injected/"
 
     log "Patching Container Manifests"
-      $DIR/tools/fix-kubelet-manifest -o $injected/manifests/public.yaml $injected/manifests/public.yaml
+    $DIR/tools/fix-kubelet-manifest ${KUBIC_MANIFEST_FLAG:-} -o $injected/manifests/public.yaml $injected/manifests/public.yaml
+
+    log "Patching activate.sh (again)"
+    if [ -n "${KUBIC_MANIFEST_FLAG:-}" ]; then
+      sed -i "s|sles12/pause:1.0.0|kubic/pause:0.1|g" $injected/activate.sh
+    fi
   else
     log "Skipping Velum environment"
   fi

--- a/caasp-kvm/tools/fix-kubelet-manifest
+++ b/caasp-kvm/tools/fix-kubelet-manifest
@@ -16,6 +16,10 @@ opts_parser = OptionParser.new do |opts|
     opts.on("-oOUTPUT", "--output OUTPUT", "Write patched manifest to specified file") do |o|
       options[:out] = o
     end
+
+    opts.on("-k", "--kubic", "Patch image names from sles to kubic") do |k|
+      options[:kubic] = k
+    end
 end
 opts_parser.parse!
 
@@ -81,6 +85,12 @@ manifest["spec"]["volumes"] << {
   "name" => "velum-devel",
   "hostPath" => {"path" => "/var/lib/misc/velum-dev" },
 }
+
+# in the devsetup we are overwriting again the kubic changes during build time
+# so again replace sles12 image path with kubic
+if options[:kubic]
+  manifest = YAML.load(YAML.dump(manifest).gsub!("sles12", "kubic"))
+end
 
 if options[:out]
   File.open(options[:out], "w") do |out|


### PR DESCRIPTION
this already happens at build time in caasp-container-manifests
but the changes are overwritten in our devsetup, so in this case
we just need to apply them again

Signed-off-by: Maximilian Meister <mmeister@suse.de>