### PR TITLE
when there's only one master/worker subtract it from removables

### DIFF
--- a/velum-bootstrap/spec/features/07-node-remove.rb
+++ b/velum-bootstrap/spec/features/07-node-remove.rb
@@ -4,6 +4,22 @@ require "yaml"
 feature "Remove a Node" do
 
   let(:node_number) { environment["minions"].count { |element| element["role"] != "admin" } }
+  let(:master_node_removable?) do
+    environment["minions"].count { |element| element["role"] == "master" }.tap do |count|
+      !count.zero? && count != 1
+    end
+  end
+  let(:worker_node_removable?) do
+    environment["minions"].count { |element| element["role"] == "worker" }.tap do |count|
+      !count.zero? && count != 1
+    end
+  end
+  let(:node_number_removable) do
+    removable = node_number
+    removable -= 1 if master_node_removable?
+    removable -= 1 if worker_node_removable?
+    removable
+  end
 
   before(:each) do
     login
@@ -23,7 +39,7 @@ feature "Remove a Node" do
     puts ">>> Checking if node can be removed"
     with_screenshot(name: :node_removable) do
       within(".nodes-container") do
-        expect(page).to have_link(text: "Remove", count: node_number, wait: 120)
+        expect(page).to have_link(text: "Remove", count: node_number_removable, wait: 120)
       end
     end
     puts "<<< A node can be removed"


### PR DESCRIPTION
Signed-off-by: Maximilian Meister <mmeister@suse.de>

@vitoravelino @inercia can you check if this logic is sufficient?

```
if there is only 1 master
  it's not removable
else
  all nodes are potentially removable
```

or is there more logic behind?