### PR TITLE
[3.0] Downloader: Fix pop from empty set

### DIFF
--- a/misc-tools/download-image
+++ b/misc-tools/download-image
@@ -41,7 +41,10 @@ class ImageFinder(HTMLParser):
             raise SystemExit(1)
 
     def get_image(self):
-        return self.images.pop().strip(" ")
+        if len(self.images) > 0:
+            return self.images.pop().strip(" ")
+        else:
+            return None
 
     def handle_data(self, data):
         m = re.search(self.regexp, data)
@@ -242,9 +245,14 @@ def get_channel_url(args):
     r = requests.get(base_url, proxies=proxies)
     parser.feed(r.text)
 
+    image = parser.get_image()
+
+    if image is None:
+        print(" >> No matching images found")
+
     return "%(base)s/%(image)s" % {
         "base": base_url,
-        "image": parser.get_image()
+        "image": image
     }
 
 


### PR DESCRIPTION
When an image is not found, we throw a cryptic error message. This
fixes that, giving a clearer error.

	[misc-tools] Running shell script
	+ set -o pipefail
	+ ./download-image --proxy **** --location **** --type kvm channel://devel
	+ tee /j/workspace/lum_PR-512-QIGXQKGO62MB6JA3Q3D4T/logs/caasp-kvm-prepare-image-caasp.log
	Traceback (most recent call last):
	  File "./download-image", line 279, in <module>
	    use_channel_file(args)
	  File "./download-image", line 67, in use_channel_file
	    remote_url = get_channel_url(args)
	  File "./download-image", line 247, in get_channel_url
	    "image": parser.get_image()
	  File "./download-image", line 44, in get_image
	    return self.images.pop().strip(" ")
	KeyError: 'pop from an empty set'
	script returned exit code 1

(cherry picked from commit 4cfcfde6bd525a7079fd3b4e472e228ff931ee05)

Backport of https://github.com/kubic-project/automation/pull/375