### PR TITLE
Apply local changes to the haproxy config using cloud-init

### DIFF
--- a/caasp-kvm/cloud-init/admin.cfg
+++ b/caasp-kvm/cloud-init/admin.cfg
@@ -40,6 +40,7 @@ bootcmd:
 
 runcmd:
   - /usr/bin/systemctl enable --now ntpd
+  - rsync -avqz --delete /usr/share/caasp-container-manifests/config/haproxy/ /etc/caasp/haproxy/
 
 # Overload image resources with devenv ones
 mounts:


### PR DESCRIPTION
Otherwise, local modifications done to the configuration of haproxy
never applies when we create a development environment. It's kind of
a corner case, but can be confusing if you are messing with the
`haproxy` configuration and creating development environments.