### PR TITLE
add make and lsb-releases pkgs for caasp-devenv

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -51,6 +51,8 @@ DIST_PACKAGES="jq \
                terraform \
                ruby-devel \
                gcc \
+               lsb-release \
+               make \ 
                terraform-provider-libvirt \
                guestfs-tools \
                qemu-kvm \


### PR DESCRIPTION
this two pkgs were hidden deps

```bash
- 
>>> [caasp-devenv] Installing CaaSP Development Environment Requiemnts
./caasp-devenv: Zeile 242: lsb-release: Kommando nicht gefunden.
>>> [caasp-devenv] Adding SUSE:CA Zypper repo
```

- make again needed for nokogiri
