### PR TITLE
enable designate dns recordsets (on off feature based on dnsentry being set to 0 or 1)

### DIFF
--- a/caasp-openstack-terraform/openstack.tfvars
+++ b/caasp-openstack-terraform/openstack.tfvars
@@ -1,8 +1,10 @@
-image_name = "CaaSP-1.0-Build30.25-GMC"
+image_name = "CaaSP-release-3.0-Build13.31"
 internal_net = "caasp-net"
-external_net = "qa-css_extern"
+external_net = "ext-net"
 admin_size = "m1.large"
 master_size = "m1.large"
-masters = 1
+masters = 3
 worker_size = "m1.large"
-workers = 2
+workers = 3
+dnsdomain = "testing.qa.caasp.suse.net"
+dnsentry = "1"

--- a/caasp-openstack-terraform/openstack.tfvars
+++ b/caasp-openstack-terraform/openstack.tfvars
@@ -7,4 +7,4 @@ masters = 3
 worker_size = "m1.large"
 workers = 3
 dnsdomain = "testing.qa.caasp.suse.net"
-dnsentry = "1"
+dnsentry = "0"


### PR DESCRIPTION
With dnsentry set to 0:

Outputs:

hostname_admin = []
hostnames_masters = []
ip_admin_external = 10.84.73.105
ip_admin_internal = 10.0.1.136
ip_masters = [
    10.84.73.106,
    10.84.73.107,
    10.84.73.114
]
ip_workers = [
    10.84.73.108,
    10.84.73.113,
    10.84.73.112
]


With dnsentry set to 1:


Outputs:

hostname_admin = [
    caasp-admin.testing.qa.caasp.suse.net.
]
hostnames_masters = [
    caasp-master0.testing.qa.caasp.suse.net.
]
ip_admin_external = 10.84.73.85
ip_admin_internal = 10.0.2.24
ip_masters = [
    10.84.73.84
]
ip_workers = [
    10.84.73.8,
    10.84.73.80,
    10.84.73.86,
    10.84.73.83,
    10.84.73.82

