### PR TITLE
increase timeout, mainly to fetch the sandbox image

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-sandbox
+++ b/jenkins-pipelines/Jenkinsfile.kubic-sandbox
@@ -7,12 +7,14 @@ properties([
     // no pipelineTriggers yet, manual trigger for now
     parameters([
         string(name: 'IMAGE', defaultValue: 'http://download.suse.de/ibs/Devel:/CASP:/SandBox/images/SUSE-CaaS-Platform-4.0-for-KVM-and-Xen.x86_64.qcow2', description: 'SandBox build'),
-        booleanParam(name: 'RUN_CONFORMANCE_TESTS', defaultValue: false, description: 'Run k8s conformance test suite')
+        booleanParam(name: 'RUN_CONFORMANCE_TESTS', defaultValue: false, description: 'Run k8s conformance test suite'),
+        string(name: 'timeout', defaultValue: '120', description: 'Timeout to fetch image builds, as the job is on demand it can take longer to fetch the image')
     ])
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
 kvmTypeOptions.image = env.IMAGE
+kvmTypeOptions.timeOut = env.timeout
 
 coreKubicProjectPeriodic(
     environmentTypeOptions: kvmTypeOptions

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -52,7 +52,7 @@ end
 Capybara.register_driver :poltergeist do |app|
   options = {
     timeout:           180,
-    js_errors:         true,
+    js_errors:         false,
     phantomjs_options: [
       "--proxy-type=none",
       "--load-images=yes"


### PR DESCRIPTION
as the job is triggered on demand we need to increase the timeout

Signed-off-by: Maximilian Meister <mmeister@suse.de>

depends on https://github.com/kubic-project/jenkins-library/pull/178