### PR TITLE
add sandbox channel and cache it regularly

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.image-cacher
+++ b/jenkins-pipelines/Jenkinsfile.image-cacher
@@ -6,7 +6,7 @@ properties([
     disableConcurrentBuilds(),
     pipelineTriggers([
         [$class: 'org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger',
-            parameterizedSpecification: 'H/15 * * * *  % CHANNEL=devel\nH * * * *  % CHANNEL=release'
+            parameterizedSpecification: 'H/15 * * * *  % CHANNEL=devel\nH * * * *  % CHANNEL=release\nH/45 * * * *  % CHANNEL=sandbox'
         ]
     ]),
     parameters([

--- a/misc-files/download-urls.json
+++ b/misc-files/download-urls.json
@@ -4,6 +4,9 @@
       "default": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode/",
       "provo": "http://nodes.provo-prod.caasp.suse.net:32501/ibs/Devel:/CASP:/Head:/ControllerNode/"
     },
+    "sandbox": {
+      "default": "http://download.suse.de/ibs/Devel:/CASP:/SandBox/"
+    },
     "kubic": {
       "default": "http://download.opensuse.org/repositories/devel:/CaaSP:/images/"
     },


### PR DESCRIPTION
in addition to https://github.com/kubic-project/automation/pull/391 it probably helps to reduce time when triggering the sandbox CI run on demand