### PR TITLE
Workaround bsc#1091097: use the kubic hardware-x86_64 image.

### DIFF
--- a/misc-tools/download-image
+++ b/misc-tools/download-image
@@ -13,7 +13,7 @@ import urlparse
 from HTMLParser import HTMLParser
 
 KVM_REGEX = '.*KVM.*x86_64-.*\.qcow2$'
-KVM_KUBIC_REGEX = '.*x86_64-.*kvm-and-xen.*\.qcow2$'
+KVM_KUBIC_REGEX = '.*x86_64-.*hardware-x86_64.*\.qcow2$'
 DOCKER_REGEX = '%(docker_image)s.*x86_64-.*\.tar\.xz$'
 OPENSTACK_REGEX = '.*OpenStack-Cloud.*x86_64-.*\.qcow2$'
 ISO_REGEX = '.*-DVD-x86_64-.*-Media1\.iso$'


### PR DESCRIPTION
The hardware-x86_64 image provides the required 9p*.ko modules for mounting
folders from the host machine into the vms.