### PR TITLE
Disable bugzilla reference checks on this repo

### DIFF
--- a/Jenkinsfile.housekeeping
+++ b/Jenkinsfile.housekeeping
@@ -2,4 +2,6 @@ def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
 
 library "kubic-jenkins-library@${targetBranch}"
 
-coreKubicProjectHousekeeping()
+coreKubicProjectHousekeeping(
+    enableBugzillaReferenceCheck: false
+)


### PR DESCRIPTION
This repo is not shipped, so theres no reason to require bug
numbers are present.

(cherry picked from commit 144a826343634e47f31a83021abb401b66a8adb8)

Backport of https://github.com/kubic-project/automation/pull/408
Depends-On: https://github.com/kubic-project/jenkins-library/pull/183