### PR TITLE
Increase k8s e2e tests timeout cause this is not enought on our test

### DIFF
--- a/k8s-e2e-tests/e2e-tests
+++ b/k8s-e2e-tests/e2e-tests
@@ -50,7 +50,10 @@ while [[ $# > 0 ]] ; do
 done
 
 run_tests() {
-    KUBECONFIG=$KUBECONFIG kubectl apply -f https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml
+    rm -f sonobuoy-sonobuoy-conformance.yaml && wget https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml
+    # Increase timeout. The default timeout is not enought when running in our test cluster
+    sed -e "s/\"timeoutseconds\": 5400/\"timeoutseconds\": 10800/g" -i sonobuoy-conformance.yaml
+    KUBECONFIG=$KUBECONFIG kubectl apply -f sonobuoy-conformance.yaml
     while ! KUBECONFIG=$KUBECONFIG kubectl logs -n sonobuoy sonobuoy | grep "sonobuoy is now blocking"; do
         sleep 1
     done


### PR DESCRIPTION
cluster

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>