### PR TITLE
JJB: Update branch matching to avoid unwated matches

### DIFF
--- a/jenkins-jobs/job-templates.yaml
+++ b/jenkins-jobs/job-templates.yaml
@@ -21,7 +21,7 @@
           discover-pr-origin: current
           # TODO: Change to continuous-integration/jenkins/integration
           notification-context: continuous-integration/jenkins
-          filter-head-includes: master release-* PR-*
+          filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$
 
 - job-template:
     name: '{name}.housekeeping'
@@ -44,7 +44,7 @@
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
           notification-context: continuous-integration/jenkins/housekeeping
-          filter-head-includes: master release-* PR-*
+          filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$
 
 - job-template:
     name: '{name}.flake8'
@@ -67,4 +67,4 @@
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
           notification-context: continuous-integration/jenkins/flake8
-          filter-head-includes: master release-* PR-*
+          filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$


### PR DESCRIPTION
Sometimes, people would use "release-2.0-foo" style branch names for
backports, which were getting matched - and too many jobs would run (and
fail, as they aren't a proper branch shared accross all repos job..)

Switch to using a regex to filter these unwated matches out