### PR TITLE
JJB: Change notification-context's to be something nicer to read

### DIFF
--- a/jenkins-jobs/job-templates.yaml
+++ b/jenkins-jobs/job-templates.yaml
@@ -19,7 +19,7 @@
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
-          # TODO: Change to continuous-integration/jenkins/integration
+          # TODO: Change to "Jenkins/Integration"
           notification-context: continuous-integration/jenkins
           filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$
 
@@ -43,7 +43,7 @@
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
-          notification-context: continuous-integration/jenkins/housekeeping
+          notification-context: "Jenkins/Housekeeping"
           filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$
 
 - job-template:
@@ -66,7 +66,7 @@
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
-          notification-context: continuous-integration/jenkins/flake8
+          notification-context: "Jenkins/Flake8"
           filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$
 
 - job-template:

--- a/jenkins-jobs/jobs.yaml
+++ b/jenkins-jobs/jobs.yaml
@@ -231,5 +231,5 @@
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
-          notification-context: "Jenkins: Jenkins Job Builder"
+          notification-context: "Jenkins/Jenkins Job Builder"
           filter-head-regex: ^(master|release\-\d\.\d|PR\-\d+)$


### PR DESCRIPTION
These will end up rendered in GitHub as:

    Jenkins/Flake8/pr-head

etc instead of:

    continuous-integration/jenkins/Flake8/pr-head