### PR TITLE
caasp-kvm: support ses team needs

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -30,6 +30,8 @@ CAASP_VELUM_DIR=${CAASP_VELUM_DIR:-$DIR/../../velum}
 CAASP_NAME_PREFIX=${CAASP_NAME_PREFIX:-}
 CAASP_BRIDGE=${CAASP_BRIDGE:-}
 
+TFVARS_FILE=${CAASP_TFVARS_FILE:-}
+
 ADMIN_RAM=${CAASP_ADMIN_RAM:-4096}
 ADMIN_CPU=${CAASP_ADMIN_CPU:-4}
 MASTER_RAM=${CAASP_MASTER_RAM:-2048}
@@ -77,6 +79,7 @@ Usage:
   * Advanced Options
 
     --plan                      Run the CaaSP KVM Plan Step
+    --tfvars-file <STR>         Path to a specific .tfvars file to use (Default: .)
     --admin-ram <INT>           RAM to allocate to admin node (Default: CAASP_ADMIN_RAM=$ADMIN_RAM)
     --admin-cpu <INT>           CPUs to allocate to admin node (Default: CAASP_ADMIN_CPU=$ADMIN_CPU)
     --master-ram <INT>          RAM to allocate to master node(s) (Default: CAASP_MASTER_RAM=$MASTER_RAM)
@@ -196,6 +199,10 @@ while [[ $# > 0 ]] ; do
       ACTION=1
       RUN_PLAN=1
       ;;
+    --tfvars-file)
+      TFVARS_FILE="$2"
+      shift
+      ;;
     --admin-ram)
       ADMIN_RAM="$2"
       shift
@@ -260,6 +267,11 @@ TF_ARGS="-parallelism=$PARALLELISM \
          -var master_vcpu=$MASTER_CPU \
          -var worker_memory=$WORKER_RAM \
          -var worker_vcpu=$WORKER_CPU"
+
+if [ ! -z "${TFVARS_FILE}" ] ; then
+  TF_ARGS="-var-file=$TFVARS_FILE \
+          ${TF_ARGS}"
+fi
 
 if [ -n "$CAASP_SALT_DIR" ] ; then
   CAASP_SALT_DIR="$(realpath $CAASP_SALT_DIR)"

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -39,6 +39,7 @@ MASTER_CPU=${CAASP_MASTER_CPU:-2}
 WORKER_RAM=${CAASP_WORKER_RAM:-2048}
 WORKER_CPU=${CAASP_WORKER_CPU:-2}
 ADDITIONAL_VOLUME_COUNT=${CAASP_ADDITIONAL_VOLUME_COUNT:-0}
+ADDITIONAL_VOLUME_SIZE=${CAASP_ADDITIONAL_VOLUME_SIZE:-10}
 
 EXTRA_REPO=${CAASP_EXTRA_REPO:-}
 
@@ -89,6 +90,7 @@ Usage:
     --extra-repo <STR>          URL of a custom repository on the master(s)/worker(s) (Default: CAASP_EXTRA_REPO)
     --name-prefix <STR>         Name prefix for the terraform resources to make multiple clusters on one host possible (Default: "")
     --additional-volumes <INT>  Number of additional blank volumes to attach to worker(s) (Default: 0)
+    --additional-vol-size <INT> Size in Gigabytes of additional volumes (Default: 10)
 
   * Examples:
 
@@ -235,6 +237,10 @@ while [[ $# > 0 ]] ; do
       ADDITIONAL_VOLUME_COUNT="$2"
       shift
       ;;
+    --additional-vol-size)
+      ADDITIONAL_VOLUME_SIZE="$2"
+      shift
+      ;;
     -h|--help)
       usage
       ;;
@@ -266,7 +272,8 @@ TF_ARGS="-parallelism=$PARALLELISM \
          -var master_memory=$MASTER_RAM \
          -var master_vcpu=$MASTER_CPU \
          -var worker_memory=$WORKER_RAM \
-         -var worker_vcpu=$WORKER_CPU"
+         -var worker_vcpu=$WORKER_CPU \
+         -var additional_volume_size=$ADDITIONAL_VOLUME_SIZE"
 
 if [ ! -z "${TFVARS_FILE}" ] ; then
   TF_ARGS="-var-file=$TFVARS_FILE \
@@ -300,7 +307,7 @@ if [ -n "$CAASP_NAME_PREFIX" ] ; then
 fi
 
 if [ -n "${ADDITIONAL_VOLUME_COUNT}" ] ; then
-  log "Adding ${ADDITIONAL_VOLUME_COUNT} volumes to worker nodes"
+  log "Adding ${ADDITIONAL_VOLUME_COUNT} volumes of size ${ADDITIONAL_VOLUME_SIZE} GB to worker nodes"
 fi
 
 # Core methods

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -36,6 +36,7 @@ MASTER_RAM=${CAASP_MASTER_RAM:-2048}
 MASTER_CPU=${CAASP_MASTER_CPU:-2}
 WORKER_RAM=${CAASP_WORKER_RAM:-2048}
 WORKER_CPU=${CAASP_WORKER_CPU:-2}
+ADDITIONAL_VOLUME_COUNT=${CAASP_ADDITIONAL_VOLUME_COUNT:-0}
 
 EXTRA_REPO=${CAASP_EXTRA_REPO:-}
 
@@ -84,6 +85,7 @@ Usage:
     --worker-cpu <INT>          CPUs to allocate to worker node(s) (Default: CAASP_WORKER_CPU=$WORKER_CPU)
     --extra-repo <STR>          URL of a custom repository on the master(s)/worker(s) (Default: CAASP_EXTRA_REPO)
     --name-prefix <STR>         Name prefix for the terraform resources to make multiple clusters on one host possible (Default: "")
+    --additional-volumes <INT>  Number of additional blank volumes to attach to worker(s) (Default: 0)
 
   * Examples:
 
@@ -222,6 +224,10 @@ while [[ $# > 0 ]] ; do
       EXTRA_REPO="$2"
       shift
       ;;
+    --additional-volumes)
+      ADDITIONAL_VOLUME_COUNT="$2"
+      shift
+      ;;
     -h|--help)
       usage
       ;;
@@ -281,10 +287,18 @@ if [ -n "$CAASP_NAME_PREFIX" ] ; then
   log "Using name prefix for terraform: $CAASP_NAME_PREFIX"
 fi
 
+if [ -n "${ADDITIONAL_VOLUME_COUNT}" ] ; then
+  log "Adding ${ADDITIONAL_VOLUME_COUNT} volumes to worker nodes"
+fi
+
 # Core methods
 render_cluster_tf() {
   log "Generating terraform manifest from erb template"
-  VANILLA=${VANILLA} CAASP_BRIDGE=${CAASP_BRIDGE} DISABLE_MELTDOWN_SPECTRE=${DISABLE_MELTDOWN_SPECTRE} erb -T - cluster.tf.erb > cluster.tf || error "Failed to generate cluster.tf, check that erb (part of Ruby) is installed correctly"
+  VANILLA=${VANILLA} CAASP_BRIDGE=${CAASP_BRIDGE} \
+    DISABLE_MELTDOWN_SPECTRE=${DISABLE_MELTDOWN_SPECTRE} \
+    ADDITIONAL_VOLUME_COUNT=${ADDITIONAL_VOLUME_COUNT} \
+      erb -T - cluster.tf.erb > cluster.tf || \
+        error "Failed to generate cluster.tf, check that erb (part of Ruby) is installed correctly"
 }
 
 build() {

--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -137,7 +137,7 @@ resource "libvirt_volume" "img" {
 ##############
 <% if ENV['CAASP_BRIDGE'] == '' -%>
 resource "libvirt_network" "network" {
-    name      = "${var.name_prefix}net"
+    name      = "${var.name_prefix}caasp-dev-net"
     mode      = "${var.net_mode}"
     domain    = "${var.name_prefix}${var.domain_name}"
     addresses = ["${var.network}"]

--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -18,6 +18,12 @@ variable "pool" {
   description = "pool to be used to store all the volumes"
 }
 
+variable "additional_volume_pool" {
+  type        = "string"
+  default     = "default"
+  description = "pool to be used for storing additional, non-os-disk volumes"
+}
+
 #####################
 # Cluster variables #
 #####################
@@ -90,6 +96,11 @@ variable "network" {
   type        = "string"
   default     = "10.17.0.0/22"
   description = "Network used by the cluster"
+}
+
+variable "additional_volume_size" {
+  default     = 10
+  description = "Size in gigabytes of additional volumes"
 }
 
 ####################
@@ -179,7 +190,7 @@ resource "libvirt_domain" "admin" {
     network_id     = "${libvirt_network.network.id}"
     hostname       = "${var.name_prefix}admin"
     addresses      = ["${cidrhost("${var.network}", 256)}"]
-<% else -%> 
+<% else -%>
     bridge = "<%= ENV['CAASP_BRIDGE'] %>"
 <% end -%>
     wait_for_lease = 1
@@ -310,7 +321,7 @@ resource "libvirt_domain" "master" {
     network_id     = "${libvirt_network.network.id}"
     hostname       = "${var.name_prefix}master-${count.index}"
     addresses      = ["${cidrhost("${var.network}", 512 + count.index)}"]
-<% else -%> 
+<% else -%>
     bridge = "<%= ENV['CAASP_BRIDGE'] %>"
 <% end -%>
     wait_for_lease = 1
@@ -349,6 +360,16 @@ resource "libvirt_volume" "worker" {
   base_volume_id = "${libvirt_volume.img.id}"
   count          = "${var.worker_count}"
 }
+
+<% if Integer(ENV['ADDITIONAL_VOLUME_COUNT']) > 0 -%>
+resource "libvirt_volume" "additional_worker_volumes" {
+  name       = "${var.name_prefix}additional-worker-volume-${ count.index / <%= ENV['ADDITIONAL_VOLUME_COUNT'] %> }-${ count.index % <%= ENV['ADDITIONAL_VOLUME_COUNT'] %> }"
+  pool       = "${var.additional_volume_pool}"
+  # size param is in bytes, so multiply by 1024 thrice to get GB
+  size       = "${var.additional_volume_size * 1024 * 1024 * 1024}"
+  count      = "${ var.worker_count * <%= ENV['ADDITIONAL_VOLUME_COUNT'] %> }"
+}
+<% end -%>
 
 data "template_file" "worker_cloud_init_user_data" {
   # needed when 0 worker nodes are defined
@@ -398,12 +419,21 @@ resource "libvirt_domain" "worker" {
     volume_id = "${element(libvirt_volume.worker.*.id, count.index)}"
   }
 
+<% if Integer(ENV['ADDITIONAL_VOLUME_COUNT']) > 0 -%>
+  # Additional disks
+  <% Range.new(0, Integer(ENV['ADDITIONAL_VOLUME_COUNT']) - 1).each do |i| -%>
+disk {
+    volume_id = "${element(libvirt_volume.additional_worker_volumes.*.id, count.index * <%= ENV['ADDITIONAL_VOLUME_COUNT'] %> + <%= i %>)}"
+  }
+  <% end -%>
+<% end -%>
+
   network_interface {
 <% if ENV['CAASP_BRIDGE'] == '' -%>
     network_id     = "${libvirt_network.network.id}"
     hostname       = "${var.name_prefix}worker-${count.index}"
     addresses      = ["${cidrhost("${var.network}", 768 + count.index)}"]
-<% else -%> 
+<% else -%>
     bridge = "<%= ENV['CAASP_BRIDGE'] %>"
 <% end -%>
     wait_for_lease = 1

--- a/caasp-kvm/terraform.tfvars.example
+++ b/caasp-kvm/terraform.tfvars.example
@@ -9,6 +9,10 @@
 # eg: a pool backed by a fast SSD
 #pool = "home_libvirtd"
 
+# A different pool can be specified for additional disks attached to workers
+# eg: a pool backed by a slow spinner
+#additional_volume_pool = "default"
+
 #####################
 # Cluster variables #
 #####################

--- a/caasp-kvm/tools/cleanup.sh
+++ b/caasp-kvm/tools/cleanup.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 echo "--> Cleanup VMs"
-sudo virsh list --all | (grep -E "(admin|(master|worker)_[0-9]+)" || :) | awk '{print $2}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh destroy {}; sudo virsh undefine {}'
+sudo virsh list --all | (grep -E "(admin|(master|worker)_[0-9]+)" || :) | awk '{print $2}' | \
+  xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh destroy {}; sudo virsh undefine {}'
 
 echo "--> Cleanup Networks"
-sudo virsh net-list --all | (grep "net" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh net-destroy {}; sudo virsh net-undefine {}'
+sudo virsh net-list --all | (grep "caasp-dev-net" || :) | awk '{print $1}' | \
+  xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh net-destroy {}; sudo virsh net-undefine {}'
 
 echo "--> Cleanup Volumes"
-sudo virsh vol-list --pool default | (grep -E "(admin(_cloud_init)?|(master|worker)(_cloud_init)?_[0-9]+)" || :) | awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c 'sudo virsh vol-delete --pool default {}'
+pools="$(sudo virsh pool-list --all | sed 1,2d | awk '{print $1}')"
+for pool in $pools; do
+sudo virsh vol-list --pool "$pool" | \
+  (grep -E "(admin(_cloud_init)?|(master|worker)(_cloud_init)?_[0-9]+)|additional-worker-volume" || :) | \
+  awk '{print $1}' | xargs --no-run-if-empty -n1 -I{} sh -c "sudo virsh vol-delete --pool '$pool' {}"
+done
 
 echo "--> Cleanup Terraform states from caasp-kvm"
 pushd $DIR/.. > /dev/null


### PR DESCRIPTION
To dev and test SES on CaaSP, workers need to be able to be created with
local storage attached. Because terraform-provider-libvirt does not have
a volume attachment, ERB templating is used to add a variable number of
additional disks to worker nodes.

Allow users to specify a custom .tfvars file to use so that our dev
environment can specify its preferred overrides without modifying the
example tfvars file in automation/caasp-kvm.