### PR TITLE
Revert "[testing] set js_errors to false"

### DIFF
--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -69,7 +69,7 @@ end
 Capybara.register_driver :poltergeist do |app|
   options = {
     timeout:           180,
-    js_errors:         false,
+    js_errors:         true,
     phantomjs_options: [
       "--proxy-type=none",
       "--load-images=yes"


### PR DESCRIPTION
Setting js_errors errors to false hides many real errors, and leads
to confusing results as rspec will just hang forever, eventually
timing out, instead of stopping and showing the failure.

The specific error mention in the original PR is a real bug in the
product, and it generally happens only very occasially. We shouldn't
just hide it!

This reverts commit 7443fe9b50e9cf09b903f2072727fcc1e0453749.

Originally introduced in https://github.com/kubic-project/automation/pull/391