### PR TITLE
Upgrade job: Update to use both stages

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -34,8 +34,19 @@ coreKubicProjectPeriodic(
     )
 
     // Run through the upgrade orchestration
-    upgradeEnvironment(
-        environment: environment
+    upgradeEnvironmentStage1(
+       environment: environment
+    )
+
+    // On master, we have no branch to switch to..
+    //stage('Switch Branch') {
+    //    dir('automation') {
+    //       sh(script: "git checkout master")
+    //    }
+    //}
+
+    upgradeEnvironmentStage2(
+       environment: environment
     )
 
     // Run the Core Project Tests again


### PR DESCRIPTION
This allows for the job to change branch where necessary. Another later
cleanup will remove the hardcoded branch name. I'm thinking adding
the hardcode is OK given we already hardcode the update repo URL a few
lines above.