### PR TITLE
Upgrade job: Update to use both stages

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -30,8 +30,18 @@ coreKubicProjectPeriodic(
     )
 
     // Run through the upgrade orchestration
-    upgradeEnvironment(
-        environment: environment
+    upgradeEnvironmentStage1(
+       environment: environment
+    )
+
+    stage('Switch Branch') {
+       dir('automation') {
+          sh(script: "git checkout release-3.0")
+       }
+    }
+
+    upgradeEnvironmentStage2(
+       environment: environment
     )
 
     // Run the Core Project Tests again


### PR DESCRIPTION
This allows for the job to change branch where necessary. Another later
cleanup will remove the hardcoded branch name. I'm thinking adding
the hardcode is OK given we already hardcode the update repo URL a few
lines above.