### PR TITLE
Increase upgrade job frequency

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -4,7 +4,8 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    pipelineTriggers([cron('H H(3-5) * * *')]),
+    // Run every two hours
+    pipelineTriggers([cron('H H/2 * * *')]),
     parameters([
         booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?')
     ]),


### PR DESCRIPTION
Increase the frequency of the upgrade job to once every two hours. The job
currently takes approx 1.5hrs to run, so this will keep a job running
almost always.