### PR TITLE
Skip upgrade job for master

### DIFF
--- a/jenkins-jobs/jobs.yaml
+++ b/jenkins-jobs/jobs.yaml
@@ -40,7 +40,7 @@
           branch-discovery: no-pr
           discover-pr-forks-strategy: false
           discover-pr-origin: false
-          filter-head-regex: ^(master|release\-\d\.\d)$
+          filter-head-regex: ^(release\-\d\.\d)$
           suppress-automatic-scm-triggering: true
 
 - job:


### PR DESCRIPTION
The master branch is the latest code, there is nothing to upgrade to - so
lets remove the job from that branch.