### PR TITLE
Add dummy unused/removed testinfra tests

### DIFF
--- a/testinfra/tests/test_common.py
+++ b/testinfra/tests/test_common.py
@@ -16,7 +16,16 @@ import pytest
 
 @pytest.mark.common
 class TestCommon(object):
-    """docstring for TestBaseEnv"""
+    @pytest.mark.removed
+    @pytest.mark.unused
+    def test_dummy_test(self, host):
+        # A dummy test that does nothing, but lets CI pass without yet having any
+        # removed/unused tests as a testinfra.xml will  be generated with at least
+        # one test. Remove once we have at least 1 test for each role+status
+        # combination.
+        pass
+
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "salt-minion"
     ])
@@ -24,6 +33,7 @@ class TestCommon(object):
         host_service = host.service(service)
         assert host_service.is_running
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "salt-minion"
     ])
@@ -31,5 +41,6 @@ class TestCommon(object):
         host_service = host.service(service)
         assert host_service.is_enabled
 
-    def test_bootstrap_grain(self, host):
+    @pytest.mark.bootstrapped
+    def test_bootstrap_grain_bootstrapped(self, host):
         assert host.salt("grains.get", "bootstrap_complete")

--- a/testinfra/tests/test_kubernetes_master.py
+++ b/testinfra/tests/test_kubernetes_master.py
@@ -19,7 +19,7 @@ import json
 
 @pytest.mark.master
 class TestKubernetesMaster(object):
-
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "kube-apiserver",
         "kube-controller-manager",
@@ -34,6 +34,7 @@ class TestKubernetesMaster(object):
         host_service = host.service(service)
         assert host_service.is_running
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "kube-apiserver",
         "kube-controller-manager",
@@ -47,9 +48,11 @@ class TestKubernetesMaster(object):
         host_service = host.service(service)
         assert host_service.is_enabled
 
+    @pytest.mark.bootstrapped
     def test_salt_role(self, host):
         assert 'kube-master' in host.salt("grains.get", "roles")
 
+    @pytest.mark.bootstrapped
     def test_kubernetes_cluster(self, host):
         host.run(
             "kubectl cluster-info dump --output-directory=/tmp/cluster_info"
@@ -72,6 +75,7 @@ class TestKubernetesMaster(object):
                 if item["Type"] is "Ready":
                     assert bool(item["Status"])
 
+    @pytest.mark.bootstrapped
     def test_salt_id(self, host):
         machine_id = host.file('/etc/machine-id').content_string.rstrip()
         assert machine_id in host.salt("grains.get", "id")

--- a/testinfra/tests/test_kubernetes_worker.py
+++ b/testinfra/tests/test_kubernetes_worker.py
@@ -18,6 +18,7 @@ import pytest
 @pytest.mark.worker
 class TestKubernetesWorker(object):
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "docker",
         "containerd",
@@ -29,6 +30,7 @@ class TestKubernetesWorker(object):
         host_service = host.service(service)
         assert host_service.is_running
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "docker",
         "container-feeder",
@@ -39,6 +41,7 @@ class TestKubernetesWorker(object):
         host_service = host.service(service)
         assert host_service.is_enabled
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "kube-apiserver",
         "kube-controller-manager",
@@ -48,6 +51,7 @@ class TestKubernetesWorker(object):
         host_service = host.service(service)
         assert host_service.is_running == False
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "kube-apiserver",
         "kube-controller-manager",
@@ -57,9 +61,11 @@ class TestKubernetesWorker(object):
         host_service = host.service(service)
         assert host_service.is_enabled == False
 
+    @pytest.mark.bootstrapped
     def test_salt_role(self, host):
         assert 'kube-minion' in host.salt("grains.get", "roles")
 
+    @pytest.mark.bootstrapped
     def test_salt_id(self, host):
         machine_id = host.file('/etc/machine-id').content_string.rstrip()
         assert machine_id in host.salt("grains.get", "id")
@@ -81,6 +87,7 @@ class TestKubernetesWorker(object):
         else:
             return True
 
+    @pytest.mark.bootstrapped
     def test_etcd_aliveness(self, host):
         # TODO: Remove the machine_id compatibility once we remove our
         #       generated hostnames.

--- a/testinfra/tests/test_kubic_admin.py
+++ b/testinfra/tests/test_kubic_admin.py
@@ -19,6 +19,7 @@ import pytest
 class TestKubicAdmin(object):
     """docstring for TestBaseEnv"""
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "docker",
         "containerd",
@@ -29,6 +30,7 @@ class TestKubicAdmin(object):
         host_service = host.service(service)
         assert host_service.is_running
 
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "docker",
         "container-feeder",
@@ -38,9 +40,11 @@ class TestKubicAdmin(object):
         host_service = host.service(service)
         assert host_service.is_enabled
 
+    @pytest.mark.bootstrapped
     def test_salt_role(self, host):
         assert 'admin' in host.salt("grains.get", "roles")
 
+    @pytest.mark.bootstrapped
     def test_etcd_aliveness(self, host):
         cmd = "etcdctl cluster-health"
         health = host.run_expect([0], cmd)

--- a/testinfra/tox.ini
+++ b/testinfra/tox.ini
@@ -14,59 +14,53 @@ passenv=ENVIRONMENT_JSON
 [testenv:admin]
 # TODO: Remove once https://github.com/kubic-project/jenkins-library/pull/159 merges
 commands =
-    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "admin or common" -v {posargs}
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(admin or common) and bootstrapped" -v {posargs}
 
 [testenv:master]
 # TODO: Remove once https://github.com/kubic-project/jenkins-library/pull/159 merges
 commands =
-    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "master or common" -v {posargs}
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(master or common) and bootstrapped" -v {posargs}
 
 [testenv:worker]
 # TODO: Remove once https://github.com/kubic-project/jenkins-library/pull/159 merges
 commands =
-    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "worker or common" -v {posargs}
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(worker or common) and bootstrapped" -v {posargs}
 
 [testenv:admin-bootstrapped]
 commands =
-    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "admin or common" -v {posargs}
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(admin or common) and bootstrapped" -v {posargs}
 
 [testenv:admin-unused]
-# TODO: Test that nothing is running...
 commands =
-    /bin/true
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(admin or common) and unused" -v {posargs}
 
 [testenv:admin-removed]
-# TODO: Test that nothing is running...
 commands =
-    /bin/true
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(admin or common) and removed" -v {posargs}
 
 [testenv:master-bootstrapped]
 commands =
-    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "master or common" -v {posargs}
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(master or common) and bootstrapped" -v {posargs}
 
 [testenv:master-unused]
-# TODO: Test that nothing is running...
 commands =
-    /bin/true
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(master or common) and unused" -v {posargs}
 
 [testenv:master-removed]
-# TODO: Test that nothing is running...
 commands =
-    /bin/true
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(master or common) and removed" -v {posargs}
 
 [testenv:worker-bootstrapped]
 commands =
-    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "worker or common" -v {posargs}
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(worker or common) and bootstrapped" -v {posargs}
 
 [testenv:worker-unused]
-# TODO: Test that nothing is running...
 commands =
-    /bin/true
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(worker or common) and unused" -v {posargs}
 
 [testenv:worker-removed]
-# TODO: Test that nothing is running...
 commands =
-    /bin/true
+    pytest --connection ssh --ssh-config={env:SSH_CONFIG:{toxinidir}/../misc-tools/environment.ssh_config} --sudo -m "(worker or common) and removed" -v {posargs}
 
 [testenv:all]
 commands =


### PR DESCRIPTION
A dummy test that does nothing, but lets CI pass without yet having any
removed/unused tests as a testinfra.xml will  be generated with at least
one test. Remove once we have at least 1 test for each role+status
combination.