### PR TITLE
Feature flags for testing

### DIFF
--- a/environment.json.example
+++ b/environment.json.example
@@ -1,50 +1,81 @@
 {
-   "dashboardHost" : "172.24.0.5",
-   "dashboardExternalHost" : "10.84.72.172",
-   "kubernetesHost" : "172.24.0.6",
-   "kubernetesExternalHost" : "10.84.72.173",
-   "sshUser" : "root",
-   "sshKey" : "/home/user/SUSE/caasp/automation/misc-files/id_shared",
-   "minions" : [
-      {
-         "index" : "0",
-         "role" : "admin",
-         "addresses" : {
-            "publicIpv4" : "10.84.72.172",
-            "privateIpv4" : "172.24.0.5"
-         },
-         "fqdn" : "test2-admin-xpi3oesblxxc.k8s.local",
-         "minionID" : "67af839105f24307bb2bf55d603c55f0"
-      },
-      {
-         "minionID" : "ac93ab2058914fad88d87702f8efc863",
-         "addresses" : {
-            "publicIpv4" : "10.84.72.173",
-            "privateIpv4" : "172.24.0.6"
-         },
-         "fqdn" : "test2-master-7lydnr7r4sum.k8s.local",
-         "role" : "master",
-         "index" : "1"
-      },
-      {
-         "minionID" : "618fb2611cfe41239be7cbdab853793c",
-         "index" : "2",
-         "role" : "worker",
-         "proxyCommand" : "ssh root@10.84.72.172 -W %h:%p",
-         "fqdn" : "test2-worker-eorkpgetfvr6-oxup2sra6zrr-azgmmxgbnbz4.k8s.local",
-         "addresses" : {
-            "privateIpv4" : "172.24.0.7"
-         }
-      },
-      {
-         "minionID" : "3746ed898269450d8966543734da6554",
-         "proxyCommand" : "ssh root@10.84.72.172 -W %h:%p",
-         "addresses" : {
-            "privateIpv4" : "172.24.0.8"
-         },
-         "fqdn" : "test2-worker-eorkpgetfvr6-4rzhx3nww5fv-glz5hrejhktm.k8s.local",
-         "role" : "worker",
-         "index" : "3"
+  "kubernetesExternalHost": "kube-api-x1.devenv.caasp.suse.net",
+  "dashboardHost": "10.17.1.0",
+  "dashboardExternalHost": "admin.devenv.caasp.suse.net",
+  "sshUser": "root",
+  "sshKey": "/home/kiall/SUSE/caasp/automation/caasp-kvm/tools/../../misc-files/id_shared",
+  "kubeConfig": {
+    "admin": "/home/kiall/SUSE/caasp/automation/velum-bootstrap/kubeconfig"
+  },
+  "minions": [
+    {
+      "minionID": "1c543671abe24d21a728b0fbed03c05a",
+      "role": "admin",
+      "index": "0",
+      "fqdn": "admin.devenv.caasp.suse.net",
+      "status": "unused",
+      "addresses": {
+        "publicIpv4": "10.17.1.0",
+        "privateIpv4": "10.17.1.0"
       }
-   ]
+    },
+    {
+      "minionID": "796baf52196d48658c83aaa8ad9bdbbe",
+      "role": "master",
+      "index": "0",
+      "fqdn": "master-0.devenv.caasp.suse.net",
+      "status": "unused",
+      "addresses": {
+        "privateIpv4": "10.17.2.0",
+        "publicIpv4": "10.17.2.0"
+      }
+    },
+    {
+      "minionID": "06f0fbc79d9447d6882b661f8428f8e5",
+      "role": "master",
+      "index": "1",
+      "fqdn": "master-1.devenv.caasp.suse.net",
+      "status": "unused",
+      "addresses": {
+        "publicIpv4": "10.17.2.1",
+        "privateIpv4": "10.17.2.1"
+      }
+    },
+    {
+      "minionID": "aff79cc65d3949fcb1f9bbd308549871",
+      "role": "master",
+      "index": "2",
+      "fqdn": "master-2.devenv.caasp.suse.net",
+      "status": "unused",
+      "addresses": {
+        "publicIpv4": "10.17.2.0",
+        "privateIpv4": "10.17.2.0"
+      },
+      "proxyCommand" : "ssh root@10.17.1.0 -W %h:%p"
+    },
+    {
+      "minionID": "902494f45b6c49999217ab516f9543ab",
+      "role": "worker",
+      "index": "0",
+      "fqdn": "worker-0.devenv.caasp.suse.net",
+      "status": "unused",
+      "addresses": {
+        "publicIpv4": "10.17.3.0",
+        "privateIpv4": "10.17.3.0"
+      },
+      "proxyCommand" : "ssh root@10.17.1.0 -W %h:%p"
+    },
+    {
+      "minionID": "9582ba08886f40c3a24afbb0c0043195",
+      "role": "worker",
+      "index": "1",
+      "fqdn": "worker-1.devenv.caasp.suse.net",
+      "status": "unused",
+      "addresses": {
+        "privateIpv4": "10.17.3.1",
+        "publicIpv4": "10.17.3.1"
+      },
+      "proxyCommand" : "ssh root@10.17.1.0 -W %h:%p"
+    }
+  ]
 }

--- a/environment.json.example
+++ b/environment.json.example
@@ -7,6 +7,18 @@
   "kubeConfig": {
     "admin": "/home/kiall/SUSE/caasp/automation/velum-bootstrap/kubeconfig"
   },
+  "features": {
+    "cri": {
+      "implementation": "docker"
+    },
+    "tiller": {
+      "enabled": true
+    },
+    "proxy": {
+      "enabled": "systemwide",
+      "http_proxy": "http://foo.bar:3128/"
+    }
+  },
   "minions": [
     {
       "minionID": "1c543671abe24d21a728b0fbed03c05a",

--- a/testinfra/setup.py
+++ b/testinfra/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup, find_packages
+from os import path
+
+setup(
+    name='testinfra-tests',
+    version='0.0.0',
+    description='CaaSP Testinfra Tests',
+    packages=find_packages(exclude=['tools']),
+)

--- a/testinfra/tests/test_kubernetes_worker.py
+++ b/testinfra/tests/test_kubernetes_worker.py
@@ -14,13 +14,12 @@
 
 import pytest
 
+from .utils import TestUtils
 
 @pytest.mark.worker
 class TestKubernetesWorker(object):
-
     @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
-        "docker",
         "containerd",
         "container-feeder",
         "kubelet",
@@ -31,8 +30,14 @@ class TestKubernetesWorker(object):
         assert host_service.is_running
 
     @pytest.mark.bootstrapped
+    @pytest.mark.skipif(
+        TestUtils.feature_matches('cri', {'implementation': 'docker'}),
+        reason="CRI is not Docker")
+    def test_docker_service_running(self, host, service):
+        assert host.service('docker').is_running
+
+    @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
-        "docker",
         "container-feeder",
         "kubelet",
         "kube-proxy"
@@ -40,6 +45,13 @@ class TestKubernetesWorker(object):
     def test_services_enabled(self, host, service):
         host_service = host.service(service)
         assert host_service.is_enabled
+
+    @pytest.mark.bootstrapped
+    @pytest.mark.skipif(
+        TestUtils.feature_matches('cri', {'implementation': 'docker'}),
+        reason="CRI is not Docker")
+    def test_docker_service_enabled(self, host, service):
+        assert host.service('docker').is_enabled
 
     @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [

--- a/testinfra/tests/utils.py
+++ b/testinfra/tests/utils.py
@@ -12,17 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import json
+
 class TestUtils(object):
 
     @staticmethod
-    def environment(cls):
+    def environment():
         env_file = os.environ.get('ENVIRONMENT_JSON', '../caasp-kvm/environment.json')
 
         with open(env_file, 'r') as f:
             env = json.load(f)
             return env
 
-    @staticmethod
+    @classmethod
     def feature_matches(cls, feature, value):
         feature_data = cls.environment().get("features", {}).get(feature, {})
         

--- a/testinfra/tests/utils.py
+++ b/testinfra/tests/utils.py
@@ -1,0 +1,29 @@
+# Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TestUtils(object):
+
+    @staticmethod
+    def environment(cls):
+        env_file = os.environ.get('ENVIRONMENT_JSON', '../caasp-kvm/environment.json')
+
+        with open(env_file, 'r') as f:
+            env = json.load(f)
+            return env
+
+    @staticmethod
+    def feature_matches(cls, feature, value):
+        feature_data = cls.environment().get("features", {}).get(feature, {})
+        
+        return set(feature_data.items()).issubset(set(value.items()))

--- a/velum-bootstrap/spec/features/01-setup-velum.rb
+++ b/velum-bootstrap/spec/features/01-setup-velum.rb
@@ -20,7 +20,47 @@ feature "Register user and configure cluster" do
 
   scenario "User configures the cluster" do
     with_screenshot(name: :configure) do
-      configure
+      puts ">>> Setting up velum"
+
+      with_status_ok do
+        visit "/setup"
+      end
+
+      fill_in "settings_dashboard", with: environment["dashboardHost"] || default_ip_address
+
+      # check Tiller checkbox
+      enable_tiller = ENV.fetch("ENABLE_TILLER", "false") == "true"
+
+      if enable_tiller == true
+        puts ">>> Enabling Tiller"
+        check "settings[tiller]"
+      else
+        puts ">>> Disabling Tiller"
+        uncheck "settings[tiller]"
+      end
+
+      environment(
+        action: :update,
+        body:   set_feature("tiller" => {"enabled" => enable_tiller})
+      )
+
+      # choose cri-o engine by pressing button
+      cri_implementation = ENV.fetch("CHOOSE_CRIO", false) == "true" ? "crio" : "docker"
+
+      if cri_implementation == "crio"
+        # using the "chose" function fails with a MouseEventFailed overlap error
+        page.find('#settings_container_runtime_crio').trigger(:click)
+      else
+        page.find('#settings_container_runtime_docker').trigger(:click)
+      end
+
+      environment(
+        action: :update,
+        body:   set_feature("cri" => {"implementation" => cri_implementation})
+      )
+
+      click_on "Next"
+      puts "<<< Velum set up"
     end
   end
 end

--- a/velum-bootstrap/spec/features/01-setup-velum.rb
+++ b/velum-bootstrap/spec/features/01-setup-velum.rb
@@ -41,7 +41,7 @@ feature "Register user and configure cluster" do
 
       environment(
         action: :update,
-        body:   set_feature("tiller" => {"enabled" => enable_tiller})
+        body:   set_feature("tiller", {"enabled" => enable_tiller})
       )
 
       # choose cri-o engine by pressing button
@@ -56,7 +56,7 @@ feature "Register user and configure cluster" do
 
       environment(
         action: :update,
-        body:   set_feature("cri" => {"implementation" => cri_implementation})
+        body:   set_feature("cri", {"implementation" => cri_implementation})
       )
 
       click_on "Next"

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -48,7 +48,7 @@ end
 # returns a new env with a feature set as $value
 def set_feature(feature, value)
   env = JSON.parse(File.read(environment_path))
-  env["feature"][feature] = value
+  env.fetch("features", {})[feature] = value
   env
 end
 

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -45,6 +45,13 @@ def set_minion_status(minion_id, status)
   env
 end
 
+# returns a new env with a feature set as $value
+def set_feature(feature, value)
+  env = JSON.parse(File.read(environment_path))
+  env["feature"][feature] = value
+  env
+end
+
 def admin_minion
   environment["minions"].detect { |m| m["role"] == "admin" }
 end

--- a/velum-bootstrap/spec/support/helpers.rb
+++ b/velum-bootstrap/spec/support/helpers.rb
@@ -47,33 +47,6 @@ module Helpers
     `ip addr show #{default_interface} | awk '$1 == "inet" {print $2}' | cut -f1 -d/`.strip
   end
 
-  def configure
-    puts ">>> Setting up velum"
-    with_status_ok do
-      visit "/setup"
-    end
-
-    fill_in "settings_dashboard", with: environment["dashboardHost"] || default_ip_address
-
-    # check Tiller checkbox
-    if ENV.fetch("ENABLE_TILLER", false) == "true"
-      puts ">>> Enabling Tiller"
-      check "settings[tiller]"
-    else
-      puts ">>> Disabling Tiller"
-      uncheck "settings[tiller]"
-    end
-
-    # choose cri-o engine by pressing button
-    if ENV.fetch("CHOOSE_CRIO", false) == "true"
-      # using the "chose" function fails with a MouseEventFailed overlap error
-      page.find('#settings_container_runtime_crio').trigger(:click)
-    else
-      page.find('#settings_container_runtime_docker').trigger(:click)
-    end
-    click_on "Next"
-    puts "<<< Velum set up"
-  end
 end
 
 RSpec.configure { |config| config.include Helpers, type: :feature }


### PR DESCRIPTION
Add support for feature flags to be passed though the CI/Test tooling. This allows for tests to be more easily written for optional features - e.g. a specific CRI implementation.

It's likely easier to review each commit is isolation.