### PR TITLE
addNode: reduce worker number

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
@@ -12,7 +12,8 @@ kvmTypeOptions.vanilla = true
 kvmTypeOptions.disableMeltdownSpectreFixes = false
 
 coreKubicProjectPeriodic(
-    environmentTypeOptions: kvmTypeOptions
+    environmentTypeOptions: kvmTypeOptions,
+    workerCount: 1
 ) {
     // empty preBootstrapBody
 } {
@@ -22,7 +23,7 @@ coreKubicProjectPeriodic(
             environment: environment,
             typeOptions: environmentTypeOptions,
             masterCount: 3,
-            workerCount: 3
+            workerCount: 2
         )
 
         // Register it via velum


### PR DESCRIPTION
as we have increased the admin ram in CI we need to scale down
on the addNode job

Error: cannot set up guest memory 'pc.ram': Cannot allocate memory

Signed-off-by: Maximilian Meister <mmeister@suse.de>