### PR TITLE
velum-bootstrap: Add remote registry spec feature

### DIFF
--- a/velum-bootstrap/spec/features/08-add-remote-registry.rb
+++ b/velum-bootstrap/spec/features/08-add-remote-registry.rb
@@ -52,5 +52,12 @@ feature "Add Remote Registry" do
       click_button "Apply changes"
     end
     puts "<<< User clicks to apply changes"
+
+    # Add remote registry information to the environment file
+    env = environment(action: :read)
+    registries = env.fetch("remoteRegistries", [])
+    env["remoteRegistries"] = registries << {"name" => remote_registry_name,
+                                             "url" => remote_registry_url}
+    environment(action: :update, body: env)
   end
 end

--- a/velum-bootstrap/spec/features/08-add-remote-registry.rb
+++ b/velum-bootstrap/spec/features/08-add-remote-registry.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "uri"
+require "yaml"
+require "openssl"
+require "net/http"
+
+feature "Add Remote Registry" do
+  before do
+    login unless inspect.include? "User registers"
+  end
+
+  # Using append after in place of after, as recommended by
+  # https://github.com/mattheworiordan/capybara-screenshot#common-problems
+  append_after do
+    Capybara.reset_sessions!
+  end
+
+  # User registration and cluster configuration has already been done in 01-setup-velum.rb
+  # After login we simply press Next to reach the minion discovery page
+  scenario "User adds a remote registry" do
+    with_screenshot(name: :remote_registries_page) do
+      with_status_ok do
+        visit "/settings/registries"
+      end
+    end
+
+    puts ">>> User clicks to add remote registry"
+    with_screenshot(name: :add_remote_registry) do
+      click_on "Add Remote Registry"
+    end
+    puts "<<< User clicks to add remote registry"
+
+    # Get the remote registry name and URL from environment variables, or use defaults that won't
+    # actually work in real life
+    remote_registry_name = ENV.fetch("REMOTE_REGISTRY_NAME", 'test-remote-registry')
+    remote_registry_url = ENV.fetch("REMOTE_REGISTRY_URL", 'https://test-remote-registry.com')
+    puts ">>> Adding remote registry " + remote_registry_name + " - " + remote_registry_url + " <<<"
+
+    puts ">>> User adds new remote registry"
+    expect(page).to have_text("New Remote Registry")
+    with_screenshot(name: :new_remote_registry) do
+      fill_in "Name", with: remote_registry_name
+      fill_in "URL", with: remote_registry_url
+      click_button "Save"
+    end
+    puts "<<< User adds new remote registry"
+
+    puts ">>> User clicks to apply changes"
+    with_screenshot(name: :apply_remote_registry_changes) do
+      expect(page).to have_text(remote_registry_name + " registry details")
+      expect(page).to have_text(remote_registry_url)
+      click_button "Apply changes"
+    end
+    puts "<<< User clicks to apply changes"
+  end
+end

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -21,6 +21,8 @@ def environment(action: :read, body: nil)
   abort("Please specify at least 2 minions in environment.json") if env["minions"].count < 2
 
   case action
+  when :read
+    env
   when :update
     if body
       File.open(environment_path, "w") do |f|

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -17,6 +17,9 @@ RUN_NODE_ADD=false
 RUN_NODE_REMOVE=false
 ENABLE_TILLER=false
 CHOOSE_CRIO=false
+RUN_ADD_REGISTRY=false
+REMOTE_REGISTRY_NAME=${REMOTE_REGISTRY_NAME:-'test-remote-registry'}
+REMOTE_REGISTRY_URL=${REMOTE_REGISTRY_URL:-'http://test-remote-registry.com'}
 
 ENVIRONMENT=${CAASP_ENVIRONMENT:-$DIR/../caasp-kvm/environment.json}
 
@@ -34,6 +37,8 @@ Usage:
     -b|--bootstrap                   Bootstrap (implies Download Kubeconfig)
     -k|--download-kubeconfig         Download Kubeconfig
     --enable-tiller                  Enable Helm Tiller
+    --registry-add                   Add a remote registry. REMOTE_REGISTRY_{NAME,URL} env vars
+                                     can be overridden to configure the repository added.
 
   * Updating a cluster
 
@@ -121,6 +126,11 @@ while [[ $# > 0 ]] ; do
       ENVIRONMENT="$2"
       shift
       ;;
+    --registry-add)
+      RUN_ADD_REGISTRY=true
+      HAS_INTERACTION=true
+      HAS_ACTION=true
+      ;;
     -h|--help)
       echo "$USAGE"
       exit 0
@@ -176,7 +186,13 @@ interact() {
     args="$args spec/**/07-*"
   fi
 
-  VERBOSE=true ENABLE_TILLER=${ENABLE_TILLER} CHOOSE_CRIO=${CHOOSE_CRIO} ENVIRONMENT=$ENVIRONMENT bundle exec rspec $args
+  if [ "$RUN_ADD_REGISTRY" = true ]; then
+    args="$args spec/**/08-*"
+  fi
+
+  VERBOSE=true ENABLE_TILLER=${ENABLE_TILLER} CHOOSE_CRIO=${CHOOSE_CRIO} ENVIRONMENT=$ENVIRONMENT \
+  REMOTE_REGISTRY_NAME="$REMOTE_REGISTRY_NAME" REMOTE_REGISTRY_URL="$REMOTE_REGISTRY_URL" \
+    bundle exec rspec $args
 
   if [ "$RUN_DOWNLOAD_KUBECONFIG" = true ]; then
     local out=$(cat $ENVIRONMENT)


### PR DESCRIPTION
Add `spec/feature/08-add-remote-registry.rb` to `velum-bootstrap`. Using
the `velum-interactions` flag `--registry-add`, add a remote
registry to Velum. Allow the environment variables
`REMOTE_REGISTRY_NAME` and `REMOTE_REGISTRY_URL` to be overridden by the
user for setting a custom registry for their environment.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>