### PR TITLE
Add deploy option to add CAP secgroup

### DIFF
--- a/caasp-openstack-heat/caasp-openstack
+++ b/caasp-openstack-heat/caasp-openstack
@@ -7,6 +7,7 @@ HAS_ACTION=false
 RUN_BUILD=false
 RUN_UPDATE=false
 RUN_DESTROY=false
+INCLUDE_CAP_PORTS=off
 
 NAME=caasp-stack
 OPENRC_FILE=
@@ -25,6 +26,8 @@ Usage:
     -m|--masters             <INT>   Number of masters to build (Default: 3)
     -w|--workers             <INT>   Number of workers to build (Default: 2)
     -i|--image               <STR>   Image to use
+    --include-cap-ports              Open additional ports for testing/deployment of SUSE Cloud Application
+                                     Platform (SUSE Cloud Foundry)
 
   * Destroying a cluster
 
@@ -103,6 +106,8 @@ while [[ $# -gt 0 ]] ; do
       echo "$USAGE"
       exit 0
       ;;
+    --include-cap-ports)
+      INCLUDE_CAP_PORTS=on
   esac
   shift
 done
@@ -124,7 +129,8 @@ build_stack() {
   openstack stack create --verbose --wait -e "$HEAT_ENVIRONMENT_FILE" -t caasp-stack.yaml "$NAME" \
     --parameter master_count=$MASTERS \
     --parameter worker_count=$WORKERS \
-    --parameter image="$IMAGE"
+    --parameter image="$IMAGE" \
+    --parameter include_cap_ports=$INCLUDE_CAP_PORTS
 
   log "CaaSP Stack Created with name $NAME"
 

--- a/caasp-openstack-heat/caasp-stack-worker.yaml
+++ b/caasp-openstack-heat/caasp-stack-worker.yaml
@@ -24,6 +24,10 @@ parameters:
     type: string
     description: >
       Name or ID of the worker secgroup
+  secgroup_cap:
+    type: string
+    description: >
+      Add cap-specific security group to worker nodes
   flavor:
     type: string
     description: Worker Flavor
@@ -64,6 +68,7 @@ resources:
       security_groups:
         - { get_param: secgroup_base }
         - { get_param: secgroup_worker }
+        - { get_param: secgroup_cap }
       user_data_format: RAW
       user_data:
         str_replace:

--- a/caasp-openstack-heat/caasp-stack.yaml
+++ b/caasp-openstack-heat/caasp-stack.yaml
@@ -8,6 +8,7 @@ parameter_groups:
     parameters:
       - image
       - root_password
+      - include_cap_ports
 
   - label: sizing
     description: Sizing Parameters
@@ -84,6 +85,10 @@ parameters:
     type: string
     description: Root Password for the VMs
     default: linux
+  include_cap_ports:
+    type: string
+    description: Add cap-specific security group to worker nodes
+    default: "off"
 
 resources:
   keypair:
@@ -140,6 +145,31 @@ resources:
           port_range_min: 8472
           port_range_max: 8472
 
+  secgroup_cap_worker_on:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+        - protocol: tcp
+          port_range_min: 2222
+          port_range_max: 2222
+        - protocol: tcp
+          port_range_min: 2793
+          port_range_max: 2793
+        - protocol: tcp
+          port_range_min: 4443
+          port_range_max: 4443
+        - protocol: tcp
+          port_range_min: 8443
+          port_range_max: 8443
+        - protocol: tcp
+          port_range_min: 20000
+          port_range_max: 20010
+
+  secgroup_cap_worker_off:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules: []
+
   secgroup_admin:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -191,20 +221,20 @@ resources:
           port_range_min: 443
           port_range_max: 443
         - protocol: tcp
+          port_range_min: 2380
+          port_range_max: 2380
+        - protocol: tcp
           port_range_min: 8080
           port_range_max: 8080
         - protocol: tcp
           port_range_min: 8081
           port_range_max: 8081
-        - protocol: tcp
-          port_range_min: 2380
-          port_range_max: 2380
-        - protocol: tcp
-          port_range_min: 10250
-          port_range_max: 10250
         - protocol: udp
           port_range_min: 8285
           port_range_max: 8285
+        - protocol: tcp
+          port_range_min: 10250
+          port_range_max: 10250
         - protocol: tcp
           port_range_min: 30000
           port_range_max: 32768
@@ -308,6 +338,7 @@ resources:
           internal_net: { get_resource: internal_network }
           secgroup_base: { get_resource: secgroup_base }
           secgroup_worker: { get_resource: secgroup_worker }
+          secgroup_cap: { get_resource: { list_join: ['_', [ 'secgroup_cap_worker', { get_param: 'include_cap_ports' } ] ] } }
           flavor: { get_param: worker_flavor }
           keypair: { get_resource: keypair }
           root_password: { get_param: root_password }


### PR DESCRIPTION
This introduces a `--include-cap-ports` option to the `caasp-openstack` deploy script.

When the deploy script is run with this option, the worker nodes will be associated with a security group which allows inbound access on ports required for CAP functionality.

When run without the option, the worker nodes will be associated with a 'no-op' security group which doesn't provide any additional rules.