### PR TITLE
Add step to remove old KVM images in download folder

### DIFF
--- a/caasp-kvm/tools/cleanup.sh
+++ b/caasp-kvm/tools/cleanup.sh
@@ -24,4 +24,9 @@ pushd $DIR/.. > /dev/null
 rm -f cluster.tf terraform.tfstate*
 popd  > /dev/null
 
+echo "--> Cleanup old KVM images"
+pushd $DIR/../../downloads > /dev/null
+ls -vr *.qcow2 | awk -F- '$1 == name{system ("rm -f \""$0"\"")}{name=$1}' 
+popd  > /dev/null
+
 echo "Creanup Done"


### PR DESCRIPTION
Added a step to remove old KVM images that are stored and kept in the downloads folder.

Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>