### PR TITLE
Added simple setup starting Kubic VMs with kubeadm role in a terraform/libvirt env

### DIFF
--- a/kubic-kvm/.gitignore
+++ b/kubic-kvm/.gitignore
@@ -1,0 +1,7 @@
+.swp
+.terraform/
+kubic-kvm
+terraform.log
+terraform.tfstate
+terraform.tfstate.backup
+

--- a/kubic-kvm/README.md
+++ b/kubic-kvm/README.md
@@ -1,0 +1,33 @@
+# kubic-kvm
+
+The goal is to provide a simple setup of three Kubic VMs.
+No fancy configuration is possible right now.
+
+## Prerequisites
+
+You're going to need at least:
+
+* `terraform`
+* [`terraform-provider-libvirt`](https://github.com/dmacvicar/terraform-provider-libvirt)
+
+Running `caasp-devenv` should install the packages.
+
+## Download the image
+
+run
+
+    ../misc-tools/download-image --type kvm https://download.opensuse.org/repositories/devel:/kubic:/images:/experimental/images_devel_kubic/openSUSE-Tumbleweed-Kubic.x86_64-15.0-kubeadm-docker-hardware-x86_64-Build5.10.qcow2
+    
+
+In order to download the VM image.
+
+# Usage
+
+Run 
+
+    $ terraform init
+    $ terraform plan
+    $ terraform apply
+    
+to start the VMs and follow [https://kubic.opensuse.org/blog/2018-08-20-kubeadm-intro/](https://kubic.opensuse.org/blog/2018-08-20-kubeadm-intro/) to initialize Kubernetes.
+    

--- a/kubic-kvm/commoninit.cfg
+++ b/kubic-kvm/commoninit.cfg
@@ -1,0 +1,28 @@
+#cloud-config
+
+# set locale
+#locale: en_GB.UTF-8
+
+# set timezone
+#timezone: Etc/UTC
+
+# Set hostname and FQDN
+hostname: kubic-kubadm-${count.index}
+
+# set root password
+chpasswd:
+  list: |
+    root:linux
+  expire: False
+
+ssh_authorized_keys:
+ - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf Unsafe Shared Key
+
+
+runcmd:
+  - systemctl enable kubelet.service
+  - systemctl enable --now docker.service
+  - "sed -i 's!KUBELET_EXTRA_ARGS=!KUBELET_EXTRA_ARGS=--cni-bin-dir=/usr/lib/cni!g' /etc/sysconfig/kubelet"
+
+
+final_message: "The system is finally up, after $UPTIME seconds"

--- a/kubic-kvm/kubic-kvm.tf
+++ b/kubic-kvm/kubic-kvm.tf
@@ -1,0 +1,79 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+variable "network" {
+  type        = "string"
+  default     = "10.17.0.0/22"
+  description = "Network used by the cluster"
+}
+
+resource "libvirt_network" "network" {
+    name      = "kubic-dev-net"
+    mode      = "nat"
+    #domain    = "local"
+    addresses = ["${var.network}"]
+}
+
+
+resource "libvirt_volume" "os_image" {
+  name = "os_image"
+  source = "../downloads/openSUSE-Tumbleweed-Kubic.x86_64-15.0-kubeadm-docker-hardware-x86_64-Build5.10.qcow2"
+}
+
+resource "libvirt_volume" "os_volume" {
+  name = "os_volume-${count.index}"
+  base_volume_id = "${libvirt_volume.os_image.id}"
+  count = 3
+}
+
+resource "libvirt_volume" "data_volume" {
+  name = "data_volume-${count.index}"
+  size = 5368709120 # 5 * 1024 * 1024 * 1024
+  count = 3
+}
+
+
+resource "libvirt_cloudinit" "commoninit" {
+  name = "commoninit-${count.index}.iso"
+  pool      = "default"
+  user_data = "${file("commoninit.cfg")}"
+  count = 3
+}
+
+
+resource "libvirt_domain" "domain" {
+  name = "kubic-kubadm-${count.index}"
+  cpu {
+       mode = "host-passthrough"
+  }
+  memory = 2048
+  disk {
+       volume_id = "${element(libvirt_volume.os_volume.*.id, count.index)}"
+  }
+  disk {
+       volume_id = "${element(libvirt_volume.data_volume.*.id, count.index)}"
+  }
+  network_interface {
+      network_id     = "${libvirt_network.network.id}"
+      wait_for_lease = true
+      addresses = ["${cidrhost("${var.network}", 768 + count.index)}"]
+  }
+  connection {
+      type     = "ssh"
+      user     = "root"
+      password = "linux"
+  }
+  cloudinit = "${element(libvirt_cloudinit.commoninit.*.id, count.index)}"
+  provisioner "remote-exec" {
+    inline = [
+        "sleep 1"
+    ]
+  }
+
+  count = 3
+}
+
+output "ips" {
+  value = "${libvirt_domain.domain.*.network_interface.0.addresses}"
+}


### PR DESCRIPTION
This is a very simple and experimental terraform config that creates three VMs.
Lots of improvements possible, but at least, it's a starting point.

See https://trello.com/c/JAN25aeM/12-official-kubic-vm-images

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>