### PR TITLE
Adds a step to clean up screenshots when running --bootstrap

### DIFF
--- a/caasp-kvm/tools/cleanup.sh
+++ b/caasp-kvm/tools/cleanup.sh
@@ -29,4 +29,9 @@ pushd $DIR/../../downloads > /dev/null
 ls -vr *.qcow2 | awk -F- '$1 == name{system ("rm -f \""$0"\"")}{name=$1}' 
 popd  > /dev/null
 
+echo "--> Cleanup screenshots"
+pushd $DIR/../../velum-bootstrap > /dev/null
+rm -rf screenshots 
+popd  > /dev/null
+
 echo "Creanup Done"


### PR DESCRIPTION
When using `caasp-devenv --bootstrap` screenshots are taken to validate the process, these screenshots pile up. Added a step to remove to folder, it is created every time `--botstrap` is run.

Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>