### PR TITLE
Fixes test case that is looking for outdated text in UI

### DIFF
--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -35,7 +35,7 @@ feature "Boostrap cluster" do
 
     puts ">>> Wait until all #{node_number} minions are pending to be accepted"
     with_screenshot(name: :pending_minions) do
-      expect(page).to have_selector("a", text: "Accept Node", count: node_number, wait: 400)
+      expect(page).to have_selector("a", text: "Accept", count: node_number, wait: 400)
     end
     puts "<<< All minions are pending to be accepted"
 


### PR DESCRIPTION
Integration test are not passing in https://github.com/kubic-project/velum/pull/647 because of a changed text in the UI form this PR is required for the other one to run. And probably will make this build fail until the other one is in place.