### PR TITLE
Adapt cloudinit api change to reflect new api in terraform-libvirt

### DIFF
--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -153,8 +153,8 @@ resource "libvirt_volume" "admin" {
   base_volume_id = "${libvirt_volume.img.id}"
 }
 
-resource "libvirt_cloudinit" "admin" {
-  name      = "${var.name_prefix}admin_cloud_init.iso"
+resource "libvirt_cloudinit_disk" "admin" {
+  name      = "${var.name_prefix}admin_cloud_init_disk.iso"
   pool      = "${var.pool}"
   user_data = "${file("cloud-init/admin.cfg")}"
 }
@@ -164,7 +164,7 @@ resource "libvirt_domain" "admin" {
   memory    = "${var.admin_memory}"
   vcpu      = "${var.admin_vcpu}"
   metadata  = "admin.${var.domain_name},admin,${count.index}"
-  cloudinit = "${libvirt_cloudinit.admin.id}"
+  cloudinit = "${libvirt_cloudinit_disk.admin.id}"
 
   cpu {
     mode = "host-passthrough"
@@ -268,7 +268,7 @@ resource "libvirt_volume" "master" {
   count          = "${var.master_count}"
 }
 
-data "template_file" "master_cloud_init_user_data" {
+data "template_file" "master_cloud_init_disk_user_data" {
   # needed when 0 master nodes are defined
   count    = "${var.master_count}"
   template = "${file("cloud-init/master.cfg.tpl")}"
@@ -280,12 +280,12 @@ data "template_file" "master_cloud_init_user_data" {
   depends_on = ["libvirt_domain.admin"]
 }
 
-resource "libvirt_cloudinit" "master" {
+resource "libvirt_cloudinit_disk" "master" {
   # needed when 0 master nodes are defined
   count     = "${var.master_count}"
-  name      = "${var.name_prefix}master_cloud_init_${count.index}.iso"
+  name      = "${var.name_prefix}master_cloud_init_disk${count.index}.iso"
   pool      = "${var.pool}"
-  user_data = "${element(data.template_file.master_cloud_init_user_data.*.rendered, count.index)}"
+  user_data = "${element(data.template_file.master_cloud_init_disk_user_data.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "master" {
@@ -293,7 +293,7 @@ resource "libvirt_domain" "master" {
   name       = "${var.name_prefix}master_${count.index}"
   memory     = "${var.master_memory}"
   vcpu       = "${var.master_vcpu}"
-  cloudinit  = "${element(libvirt_cloudinit.master.*.id, count.index)}"
+  cloudinit  = "${element(libvirt_cloudinit_disk.master.*.id, count.index)}"
   metadata   = "master-${count.index}.${var.domain_name},master,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 
@@ -371,7 +371,7 @@ resource "libvirt_volume" "additional_worker_volumes" {
 }
 <% end -%>
 
-data "template_file" "worker_cloud_init_user_data" {
+data "template_file" "worker_cloud_init_disk_user_data" {
   # needed when 0 worker nodes are defined
   count    = "${var.worker_count}"
   template = "${file("cloud-init/worker.cfg.tpl")}"
@@ -383,12 +383,12 @@ data "template_file" "worker_cloud_init_user_data" {
   depends_on = ["libvirt_domain.admin"]
 }
 
-resource "libvirt_cloudinit" "worker" {
+resource "libvirt_cloudinit_disk" "worker" {
   # needed when 0 worker nodes are defined
   count     = "${var.worker_count}"
-  name      = "${var.name_prefix}worker_cloud_init_${count.index}.iso"
+  name      = "${var.name_prefix}worker_cloud_init_disk${count.index}.iso"
   pool      = "${var.pool}"
-  user_data = "${element(data.template_file.worker_cloud_init_user_data.*.rendered, count.index)}"
+  user_data = "${element(data.template_file.worker_cloud_init_disk_user_data.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "worker" {
@@ -396,7 +396,7 @@ resource "libvirt_domain" "worker" {
   name       = "${var.name_prefix}worker_${count.index}"
   memory     = "${var.worker_memory}"
   vcpu       = "${var.worker_vcpu}"
-  cloudinit  = "${element(libvirt_cloudinit.worker.*.id, count.index)}"
+  cloudinit  = "${element(libvirt_cloudinit_disk.worker.*.id, count.index)}"
   metadata   = "worker-${count.index}.${var.domain_name},worker,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 


### PR DESCRIPTION
### What do this PR?

in the v0.5.00 of `terraform-libvirt-plugin` the API for the `libvirt_cloudinit` will change to `libvirt_cloudinit_disk`.

This PR will adapt the kubic-terraform tf files to reflect this change.

### What is needed for this PR to be merged?


- [x]  Upstream PR get merged https://github.com/dmacvicar/terraform-provider-libvirt/pull/410
- [x] test locally this PR if it works
- [x]  In kubic-ci you need the latest plugin to be installed

### additional info:

with the 0.5.0 version doing multiples time `terraform plan` with a `cloud_init_disk` resource doesn't produce anymore any resource creation for nothing, see issue https://github.com/dmacvicar/terraform-provider-libvirt/issues/313
