### PR TITLE
FIX bsc#1099985 changes test to check on standard parts of the UI

### DIFF
--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -50,12 +50,6 @@ feature "Boostrap cluster" do
       click_button("accept-all")
     end
 
-    puts ">>> Waiting 120 seconds as a workaround"
-    # ugly workaround for https://bugzilla.suse.com/show_bug.cgi?id=1050450
-    # FIXME: drop it when bug is fixed
-    sleep 120
-    puts "<<< Waiting 120 seconds as a workaround"
-
     with_status_ok do
       visit "/setup/discovery"
     end
@@ -64,7 +58,7 @@ feature "Boostrap cluster" do
     accept_timeout = [[240, node_number * 30].max, 600].min
     puts ">>> Wait until Minion keys are accepted by salt (Timeout: #{accept_timeout})"
     with_screenshot(name: :accepted_keys) do
-      expect(page).to have_css("input[name='roles[worker][]']", count: node_number, wait: accept_timeout)
+      expect(page).to have_css(".master-btn", count: node_number, wait: accept_timeout)
     end
     puts "<<< Minion keys accepted in Velum"
 


### PR DESCRIPTION
This test are changing a part that in this PR changes https://github.com/kubic-project/velum/pull/647

Also deleted a extra step that had a note to be removed as soon as this [bug](https://bugzilla.suse.com/show_bug.cgi?id=1050450) was fixed, didn't break anything and made the specs go 120 seconds faster.