### PR TITLE
Bare metal: add temporary ISO URL

### DIFF
--- a/caasp-bare-metal/deployer/deploy_testbed.py
+++ b/caasp-bare-metal/deployer/deploy_testbed.py
@@ -696,13 +696,16 @@ def handle_iso(args):
         else:
             baseurl = j["baseurl"][args.channel]["default"]
     iso_list_url = os.path.join(baseurl, 'images/iso')
+    # FIXME
+    iso_list_url = "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode/images-sle15/iso"
 
     # regexp - general enough for all Build<NNN> Media1 ISOs
-    iso_pattern = 'SUSE\\-CaaS\\-Platform\\-\\d+.\\d+\\-DVD\\-x86_64\\-Build(\\d+)\\-Media1\\.iso$'
+    iso_pattern = 'SUSE\\-CaaS\\-Platform\\-\\d+.\\d+\\-DVD\\-x86_64\\-Build(\\d+)\\.?\\d*\\-Media1\\.iso$'
 
     if args.start_iso_fetching or args.wait_iso_fetching:
         # The BMM will start fetching a new ISO, if available
-        log.info("Checking for new ISO")
+        log.info("Checking for new ISO at URL: %s", iso_list_url)
+        log.info("Pattern: %s", iso_pattern)
         status = tsclient.update_iso(iso_list_url, iso_pattern)
         if status["running"] is None:
             log.info("No new ISO to download")


### PR DESCRIPTION
Allow testing 4.0 ISOs in the master bare metal pipeline.
(Temporary hack to be reverted once the ISO is moved to the correct URL)