### PR TITLE
Do not install packages during CI

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -239,8 +239,7 @@ export ENVIRONMENT="$DIR/caasp-kvm/environment.json"
 # Core methods
 setup() {
   log "Installing CaaSP Development Environment Requiemnts"
-  # || : is necessary, as Zypper exits non-zero for "no changes".
-  sudo zypper in --no-confirm $EARLY_DIST_PACKAGES || :
+  sudo zypper in --no-confirm --auto-agree-with-licenses $EARLY_DIST_PACKAGES
 
   local dist=$(lsb-release -sd | tr -d '"' | tr " " "_")
 
@@ -262,8 +261,7 @@ setup() {
     sudo zypper --gpg-auto-import-keys ref systemsmanagement_terraform
   fi
 
-  # || : is necessary, as Zypper exits non-zero for "no changes".
-  sudo zypper in --no-confirm $DIST_PACKAGES || :
+  sudo zypper in --no-confirm --auto-agree-with-licenses $DIST_PACKAGES
 
   # Enable and start services, if disabled
   sudo systemctl enable --now docker

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -68,6 +68,25 @@ warn()       { log "WARNING: $@" ; }
 error()      { log "ERROR: $@" ; exit 1 ; }
 check_file() { if [ ! -f $1 ]; then error "File $1 doesn't exist!"; fi }
 
+# Test methods
+is_ci()
+{
+    if [ -e /boot/grub2/grub.cfg ] && grep 'jenkins-worker' /boot/grub2/grub.cfg > /dev/null; then
+        echo "This image is generated for Jenkins CI purposes."
+        return
+    fi
+    false
+}
+
+# Velum interaction packages
+which ruby || error "Ruby is not installed"
+ruby_version=$(ruby --version | cut -d ' ' -f2 | cut -d '.' -f1-2)
+INTERACTION_PACKAGES="ruby${ruby_version}-rubygem-bundler \
+                      ruby${ruby_version}-devel \
+                      phantomjs \
+                      libxml2-devel \
+                      libxslt-devel"
+
 # parse options
 while [[ $# > 0 ]] ; do
   case $1 in
@@ -131,12 +150,16 @@ done
 
 # Core methods
 setup() {
-  log "Installing Velum Interaction Requiemnts"
+  log "Installing Velum Interaction Requirements"
 
-  local ruby_version=$(ruby --version | cut -d ' ' -f2 | cut -d '.' -f1-2)
-
-  # || : is necessary, as Zypper exits non-zero for "no changes".
-  sudo zypper in --no-confirm ruby${ruby_version}-rubygem-bundler ruby-devel phantomjs libxml2-devel libxslt-devel || :
+  if is_ci; then
+    if zypper lr > /dev/null; then
+        error "No repositories should be present into the CI environment!"
+    fi
+    rpm -q $INTERACTION_PACKAGES || error "Some packages are not pre-installed into the CI environment."
+  else
+    sudo zypper in --no-confirm --auto-agree-with-licenses $INTERACTION_PACKAGES
+  fi
 
   bundle install --without=travis_ci --path .bundler
 }


### PR DESCRIPTION
The installation of `$DIST_PACKAGES` and `$EARLY_DIST_PACKAGES` happens
only outside of the CI, so the Jenkins base image should come
pre-baked with the correct packages. Any installation attempt that
happens during the CI should fail.