### PR TITLE
Add download location for images to test salt versions

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-salt-next
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-salt-next
@@ -1,0 +1,33 @@
+def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
+def kubicLib = library("kubic-jenkins-library@${targetBranch}").com.suse.kubic
+
+// This pipeline runs end-to-end tests daily against images that are build using
+// the next salt version-upgrade that will likely be released.
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('H H(3-5) * * *')])
+])
+
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.vanilla = true
+kvmTypeOptions.disableMeltdownSpectreFixes = false
+kvmTypeOptions.image = "channel://devel_salt_next"
+
+coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions,
+    environmentDestroy: env.ENVIRONMENT_DESTROY.toBoolean(),
+    masterCount: env.MASTER_COUNT.toInteger(),
+    workerCount: env.WORKER_COUNT.toInteger(),
+) {
+    // empty preBootstrapBody
+} {
+    // Run the Core Project Tests again
+    coreKubicProjectTests(
+        environment: environment,
+        podName: 'default',
+    )
+
+    return environment
+}

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-salt-update
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-salt-update
@@ -1,0 +1,35 @@
+def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubic
+
+// This pipeline runs end-to-end tests daily against images that are build using
+// the current salt version with all patches included (also those not yet released)
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
+    parameters([
+        string(name: 'MASTER_COUNT', defaultValue: '3', description: 'Number of Master Nodes'),
+        string(name: 'WORKER_COUNT', defaultValue: '2', description: 'Number of Worker Nodes'),
+        booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done'),
+    ])
+])
+
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.image = "channel://devel_salt_update"
+
+coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions,
+    environmentDestroy: env.ENVIRONMENT_DESTROY.toBoolean(),
+    masterCount: env.MASTER_COUNT.toInteger(),
+    workerCount: env.WORKER_COUNT.toInteger(),
+) {
+    // empty preBootstrapBody
+} {
+    // Run the Core Project Tests again
+    coreKubicProjectTests(
+        environment: environment,
+        podName: 'default',
+    )
+
+    return environment
+}

--- a/misc-files/download-urls.json
+++ b/misc-files/download-urls.json
@@ -8,6 +8,12 @@
       "default": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode/",
       "provo": "http://mirror.caasp.suse.net/ibs/Devel:/CASP:/Head:/ControllerNode/"
     },
+    "devel_salt_update": {
+      "default": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode:/salt-update/"
+    },
+    "devel_salt_next": {
+      "default": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode:/salt-next/"
+    },
     "sandbox": {
       "default": "http://download.suse.de/ibs/Devel:/CASP:/SandBox/"
     },


### PR DESCRIPTION
There are new build service projects to test upcoming salt-versions for CaaSP.

This allows selecting these versions in the automation.