### PR TITLE
Remove checking for containerd.service

### DIFF
--- a/testinfra/tests/test_kubernetes_master.py
+++ b/testinfra/tests/test_kubernetes_master.py
@@ -25,7 +25,6 @@ class TestKubernetesMaster(object):
         "kube-apiserver",
         "kube-controller-manager",
         "kube-scheduler",
-        "containerd",
         "container-feeder",
         "kubelet",
         "kube-proxy"

--- a/testinfra/tests/test_kubernetes_worker.py
+++ b/testinfra/tests/test_kubernetes_worker.py
@@ -20,7 +20,6 @@ from .utils import TestUtils
 class TestKubernetesWorker(object):
     @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
-        "containerd",
         "container-feeder",
         "kubelet",
         "kube-proxy"

--- a/testinfra/tests/test_kubic_admin.py
+++ b/testinfra/tests/test_kubic_admin.py
@@ -22,7 +22,6 @@ class TestKubicAdmin(object):
     @pytest.mark.bootstrapped
     @pytest.mark.parametrize("service", [
         "docker",
-        "containerd",
         "container-feeder",
         "kubelet",
     ])


### PR DESCRIPTION
In the current docker package this service does no longer exist:
https://build.opensuse.org/package/view_file/Virtualization:containers/docker/docker.spec?expand=1