### PR TITLE
Allow SLE15 as devenv

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -255,6 +255,8 @@ if [[ $(basename $IMAGE) =~ [Kk]ubic ]]; then
   DIST=kubic
   KUBIC_MANIFEST_FLAG="--kubic"
 # check if internal network is reachable and fail early
+elif [[ $(basename $IMAGE) =~ [Dd]evel_15 ]]; then
+  SLE15_MANIFEST_FLAG="--sle15"
 elif [[ -n "$RUN_BUILD" ]] && ! ping -q -c1 download.suse.de 2>&1 >/dev/null; then
   cat <<EOF
 Internal network not reachable!
@@ -344,7 +346,15 @@ build() {
     cp -r $CAASP_MANIFESTS_DIR/* "$injected/"
 
     log "Patching Container Manifests"
-    $DIR/tools/fix-kubelet-manifest ${KUBIC_MANIFEST_FLAG:-} -o $injected/manifests/public.yaml $injected/manifests/public.yaml
+    $DIR/tools/fix-kubelet-manifest ${SLE15_MANIFEST_FLAG:-} ${KUBIC_MANIFEST_FLAG:-} -o $injected/manifests/public.yaml $injected/manifests/public.yaml
+
+    if [ -n "${SLE15_MANIFEST_FLAG:-}" ]; then
+        log "Patching additional manifests and activate.sh to use registry images"
+        $DIR/tools/fix-kubelet-manifest ${SLE15_MANIFEST_FLAG:-} --noinit -o $injected/manifests/private.yaml $injected/manifests/private.yaml
+        $DIR/tools/fix-kubelet-manifest ${SLE15_MANIFEST_FLAG:-} --noinit -o $injected/manifests/haproxy.yaml $injected/manifests/haproxy.yaml
+        sed -i "s|sles12/pause:1.0.0|registry.suse.de/devel/casp/3.0/controllernode/images_container_base/sles12/pause:1.0.0|g" $injected/activate.sh
+        sed -i "s|use_registry: false|use_registry: true|g" $injected/config/registry/registry-config.yaml
+    fi
 
     log "Patching activate.sh (again)"
     if [ -n "${KUBIC_MANIFEST_FLAG:-}" ]; then

--- a/caasp-kvm/tools/fix-kubelet-manifest
+++ b/caasp-kvm/tools/fix-kubelet-manifest
@@ -20,6 +20,14 @@ opts_parser = OptionParser.new do |opts|
     opts.on("-k", "--kubic", "Patch image names from sles to kubic") do |k|
       options[:kubic] = k
     end
+
+    opts.on("--sle15", "Patch image sources to registry") do |f|
+      options[:sle15] = f
+    end
+
+    opts.on("--noinit", "Do not perform initContainer patching") do |n| 
+      options[:noinit] = n
+    end
 end
 opts_parser.parse!
 
@@ -29,34 +37,45 @@ if ARGV.size != 1
   exit 1
 end
 
+image_versions = {
+  'mariadb' => '10.0',
+  'haproxy' => '1.6.0',
+  'salt-master' => '2018.3.0',
+  'salt-minion' => '2018.3.0',
+  'salt-api' => '2018.3.0',
+  'openldap' => '10.0'
+}
+
 manifest = YAML.load_file(ARGV[0])
 
-# Extend init containers to also set up `test` database by reusing the production database set up
-# logic.
-manifest["spec"]["initContainers"] ||= Array.new
-manifest["spec"]["initContainers"] += [
-  {
-    "name" => "mariadb-user-secrets-test",
-    "image" => "sles12/mariadb:__TAG__",
-    "command" => ["/setup-mysql.sh"],
-    "env" => [{ "name" => "ENV", "value" => "test" }],
-    "volumeMounts" => [
-      {
-        "mountPath" => "/infra-secrets",
-        "name" => "infra-secrets"
-      },
-      {
-        "mountPath" => "/var/run/mysql",
-        "name" => "mariadb-unix-socket"
-      },
-      {
-        "mountPath" => "/setup-mysql.sh",
-        "name" => "setup-mysql",
-        "readOnly" => true
-      }
-    ]
-  }
-]
+unless options[:noinit]
+  # Extend init containers to also set up `test` database by reusing the production database set up
+  # logic.
+  manifest["spec"]["initContainers"] ||= Array.new
+  manifest["spec"]["initContainers"] += [
+    {
+      "name" => "mariadb-user-secrets-test",
+      "image" => "sles12/mariadb:__TAG__",
+      "command" => ["/setup-mysql.sh"],
+      "env" => [{ "name" => "ENV", "value" => "test" }],
+      "volumeMounts" => [
+        {
+          "mountPath" => "/infra-secrets",
+          "name" => "infra-secrets"
+        },
+        {
+          "mountPath" => "/var/run/mysql",
+          "name" => "mariadb-unix-socket"
+        },
+        {
+          "mountPath" => "/setup-mysql.sh",
+          "name" => "setup-mysql",
+          "readOnly" => true
+        }
+      ]
+    }
+  ]
+end
 
 # Extend velum containers to use the development image, mount the source code and also set
 # the development environment variable for the rails environment.
@@ -85,6 +104,7 @@ def patch_containers(containers)
 end
 
 patch_containers manifest["spec"]["initContainers"]
+
 patch_containers manifest["spec"]["containers"]
 
 # Add manifest volumes where Velum source code resides in order to mount it in the containers
@@ -99,6 +119,13 @@ manifest["spec"]["volumes"] << {
 # so again replace sles12 image path with kubic
 if options[:kubic]
   manifest = YAML.load(YAML.dump(manifest).gsub!("sles12", "kubic"))
+end
+
+if options[:sle15]
+  manifest = YAML.safe_load(YAML.dump(manifest).gsub(/sles12\/(.*):__TAG__/, 'registry.suse.de/devel/casp/3.0/controllernode/images_container_base/sles12/\1:__TAG__'))
+  image_versions.each do |k, v|
+    manifest = YAML.safe_load(YAML.dump(manifest).gsub("#{k}:__TAG__", "#{k}:#{v}"))
+  end
 end
 
 if options[:out]

--- a/jenkins-pipelines/Jenkinsfile.kubic-sle15
+++ b/jenkins-pipelines/Jenkinsfile.kubic-sle15
@@ -1,0 +1,28 @@
+def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
+def kubicLib = library("kubic-jenkins-library@${targetBranch}").com.suse.kubic
+
+// Run a build using the SLE15 based image daily.
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('H H(3-5) * * *')])
+])
+
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.vanilla = true
+kvmTypeOptions.disableMeltdownSpectreFixes = false
+kvmTypeOptions.image = "channel://devel_15"
+
+coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions,
+    environmentDestroy: env.ENVIRONMENT_DESTROY.toBoolean(),
+    masterCount: env.MASTER_COUNT.toInteger(),
+    workerCount: env.WORKER_COUNT.toInteger(),
+){}
+{
+    coreKubicProjectTests(
+        environment: environment,
+        podName: 'default',
+    )
+    return environment
+}

--- a/misc-files/download-urls.json
+++ b/misc-files/download-urls.json
@@ -4,6 +4,10 @@
       "default": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode/",
       "provo": "http://mirror.caasp.suse.net/ibs/Devel:/CASP:/Head:/ControllerNode/"
     },
+    "devel_15": {
+      "default": "http://download.suse.de/ibs/Devel:/CASP:/Head:/ControllerNode/",
+      "provo": "http://mirror.caasp.suse.net/ibs/Devel:/CASP:/Head:/ControllerNode/"
+    },
     "sandbox": {
       "default": "http://download.suse.de/ibs/Devel:/CASP:/SandBox/"
     },

--- a/misc-tools/download-image
+++ b/misc-tools/download-image
@@ -13,6 +13,7 @@ import urlparse
 from HTMLParser import HTMLParser
 
 KVM_REGEX = '.*KVM.*x86_64-.*\.qcow2$'
+KVM_SLE15_REGEX = '.*CaaSP-Stack.*kvm.*\.qcow2$'
 KVM_KUBIC_REGEX = '.*x86_64-.*Stack-hardware-x86_64.*\.qcow2$'
 DOCKER_REGEX = '%(docker_image)s.*x86_64-.*\.tar\.xz$'
 OPENSTACK_REGEX = '.*OpenStack-Cloud.*x86_64-.*\.qcow2$'
@@ -33,6 +34,8 @@ class ImageFinder(HTMLParser):
         elif args.type == "kvm":
             if args.url == "channel://kubic":
                 self.regexp = KVM_KUBIC_REGEX
+            elif args.url == "channel://devel_15":
+                self.regexp = KVM_SLE15_REGEX
             else:
                 self.regexp = KVM_REGEX
         elif args.type == "openstack":
@@ -253,6 +256,8 @@ def get_channel_url(args):
         base_url += 'images_container_base'
     elif args.type in ["kvm", "openstack"]:
         base_url += 'images'
+        if args.url == "channel://devel_15":
+            base_url += '-sle15'
     elif args.type == "iso":
         base_url += 'images/iso'
     else:


### PR DESCRIPTION
This PR adds a new channel `devel_15`, that will use the new `qcow2` images for SLE15 and patch the container manifests to use docker-images from `registry.suse.de`.