### PR TITLE
only ping on build

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -255,7 +255,7 @@ if [[ $(basename $IMAGE) =~ [Kk]ubic ]]; then
   DIST=kubic
   KUBIC_MANIFEST_FLAG="--kubic"
 # check if internal network is reachable and fail early
-elif ! ping -q -c1 download.suse.de 2>&1 >/dev/null; then
+elif [[ -n "$RUN_BUILD" ]] && ! ping -q -c1 download.suse.de 2>&1 >/dev/null; then
   cat <<EOF
 Internal network not reachable!
   use $0 --image channel://kubic


### PR DESCRIPTION
I'm pretty sure the only time VPN connectivity is needed is during build, and it's mildly aggravating when destroy complains that it can't ping. :)