### PR TITLE
WIP: Re-Enable parallel terraform resources

### DIFF
--- a/caasp-kvm/README.md
+++ b/caasp-kvm/README.md
@@ -98,7 +98,6 @@ sudo virsh pool-start default
 
       * Common options
 
-        -p|--parallelism            Set terraform parallelism (Default: CAASP_PARALLELISM)
         -P|--proxy                  Set HTTP proxy (Default: CAASP_HTTP_PROXY)
         -L|--location               Set location used for downloads (Default: CAASP_LOCATION or 'default')
 

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -22,7 +22,7 @@ VANILLA=${CAASP_VANILLA:-}
 DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-}
 PROXY=${CAASP_HTTP_PROXY:-}
 LOCATION=${CAASP_LOCATION:-}
-PARALLELISM=${CAASP_PARALLELISM:-1}
+PARALLELISM=${CAASP_PARALLELISM:-}
 
 CAASP_SALT_DIR=${CAASP_SALT_DIR:-$DIR/../../salt}
 CAASP_MANIFESTS_DIR=${CAASP_MANIFESTS_DIR:-$DIR/../../caasp-container-manifests}
@@ -67,7 +67,6 @@ Usage:
 
   * Common options
 
-    -p|--parallelism            Set terraform parallelism (Default: CAASP_PARALLELISM)
     -P|--proxy                  Set HTTP proxy (Default: CAASP_HTTP_PROXY)
     -L|--location               Set location used for downloads (Default: CAASP_LOCATION or 'default')
 
@@ -156,10 +155,6 @@ while [[ $# > 0 ]] ; do
       ;;
     --disable-meltdown-spectre-fixes)
       DISABLE_MELTDOWN_SPECTRE="true"
-      ;;
-    -p|--parallelism)
-      PARALLELISM="$2"
-      shift
       ;;
     -P|--proxy)
       PROXY="$2"
@@ -263,8 +258,7 @@ EOF
   exit 1
 fi
 
-TF_ARGS="-parallelism=$PARALLELISM \
-         -var img_source_url=$IMAGE \
+TF_ARGS="-var img_source_url=$IMAGE \
          -var master_count=$MASTERS \
          -var worker_count=$WORKERS \
          -var admin_memory=$ADMIN_RAM \


### PR DESCRIPTION
We should allow TF resources  to be run in parallel.

in the past there were a bug on libvirt side, but the patch got applied.

See here for more details etc..
https://github.com/dmacvicar/terraform-provider-libvirt/issues/402#issuecomment-419500064
(especially this fix `util: don't check for parallel iteration in hash-related functions (rhbz#1581364)`
What we need to check is if the Worker on CI have this patch 

# TODOs:

check if worker have the `libvirt-patch` applied ```x util: don't check for parallel iteration in hash-related functions (rhbz#1581364)```