### PR TITLE
 Wait dynamically instead of wasting 120 seconds

### DIFF
--- a/velum-bootstrap/.rubocop.yml
+++ b/velum-bootstrap/.rubocop.yml
@@ -57,7 +57,7 @@ RSpec/MultipleExpectations:
     - spec/features/**/*
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   TargetRailsVersion: 4.2
 
   DisplayCopNames: true

--- a/velum-bootstrap/spec/features/06-node-add.rb
+++ b/velum-bootstrap/spec/features/06-node-add.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "yaml"
+require "timeout"
 
 feature "Add a Node" do
   before do
@@ -30,19 +31,15 @@ feature "Add a Node" do
       click_button("accept-all")
     end
 
-    puts ">>> Waiting 120 seconds as a workaround"
-    # ugly workaround for https://bugzilla.suse.com/show_bug.cgi?id=1050450
-    # FIXME: drop it when bug is fixed
-    sleep 120
-    puts "<<< Waiting 120 seconds as a workaround"
-
     # wait for new link to appear
-    puts ">>> Wait for new-node link to be enabled"
+    max_timeout = 240
     with_screenshot(name: :new_node_link_enabled) do
-      expect(page).to have_link(class: "assign-nodes-link", wait: 120)
+      wait_until_true(timeout: max_timeout) do
+	      expect(page).to have_link(class: "assign-nodes-link"
+      end
     end
-    puts "<<< new node link enabled"
 
+    puts "<<< new node link enabled"
     with_status_ok do
       visit "/assign_nodes"
     end

--- a/velum-bootstrap/spec/support/helpers.rb
+++ b/velum-bootstrap/spec/support/helpers.rb
@@ -6,6 +6,21 @@ module Helpers
     yield
     save_screenshot("screenshots/#{Time.now.to_i}_after_#{name}.png", full: true)
   end
+  
+  # run function until it is ok for a timeout time
+  # the callback/function ned to return true or false
+  # otherwise fail
+  def wait_until_true(timeout:)
+    puts ">>> Wait for new-node link to be enabled for max #{timeout} seconds"
+    Timeout.timeout(timeout) do
+      until yield do
+        sleep 1
+      end
+    end
+    rescue Timeout::Error
+      puts "Error: timeout reached before function was successfull"
+      false
+  end
 
   def with_status_ok
     yield


### PR DESCRIPTION
# What does this PR:

1) Introduce function which will wait dynamically https://github.com/kubic-project/automation/pull/529/files#diff-611e4142df421de6a9c053afa84ae6d8R13

Usage in codebase: 
2) remove sleep120
3) remove other sleeps