### PR TITLE
Validate cli options passed to scripts

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -220,6 +220,10 @@ while [[ $# > 0 ]] ; do
     -h|--help)
       usage
       ;;
+    *)
+      log "Invalid option: $1"
+      usage
+      ;;
   esac
   shift
 done

--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -244,6 +244,10 @@ while [[ $# > 0 ]] ; do
     -h|--help)
       usage
       ;;
+    *)
+      log "Invalid option: $1"
+      usage
+      ;;
   esac
   shift
 done

--- a/caasp-openstack-heat/caasp-openstack
+++ b/caasp-openstack-heat/caasp-openstack
@@ -103,6 +103,10 @@ while [[ $# -gt 0 ]] ; do
       echo "$USAGE"
       exit 0
       ;;
+    *)
+      log "Invalid option: $1"
+      usage
+      ;;
   esac
   shift
 done


### PR DESCRIPTION
Validate cli options and throw error message and stop if one is not recognized.

Presently invalid cli options are silently ignored. A typo in specifying an option will cause the action not no be executed without warning.  For example:

 caasp-kvm --build -m 1 -w 1 --botstrap   (notice the typo in 'botstrap' instead of 'bootstrap')

will create a cluster but will not bootstrap it. Execution looks correct, but the K8s cluster is not actually deployed.

This is particularly troublesome for beginners who don't know what is the expected output of executing an action.

Signed-off-by: Pablo Chacin <pchacin@suse.com>