### PR TITLE
fix missing sudo in velum-interations setup

### DIFF
--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -76,7 +76,7 @@ check_file() { if [ ! -f $1 ]; then error "File $1 doesn't exist!"; fi }
 # Test methods
 is_ci()
 {
-    if [ -e /boot/grub2/grub.cfg ] && sudo grep 'jenkins-worker' /boot/grub2/grub.cfg > /dev/null; then
+    if [ -f /boot/grub2/grub.cfg ] && sudo grep -q 'jenkins-worker' /boot/grub2/grub.cfg; then
         echo "This image is generated for Jenkins CI purposes."
         return
     fi

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -76,7 +76,7 @@ check_file() { if [ ! -f $1 ]; then error "File $1 doesn't exist!"; fi }
 # Test methods
 is_ci()
 {
-    if [ -e /boot/grub2/grub.cfg ] && grep 'jenkins-worker' /boot/grub2/grub.cfg > /dev/null; then
+    if [ -e /boot/grub2/grub.cfg ] && sudo grep 'jenkins-worker' /boot/grub2/grub.cfg > /dev/null; then
         echo "This image is generated for Jenkins CI purposes."
         return
     fi


### PR DESCRIPTION
I was running some CI but the velum-interations step fails because a sudo is missing:

>>> [velum-bootstrap] Installing Velum Interaction Requirements
grep: /boot/grub2/grub.cfg: Permission denied

Signed-off-by: Ludovic Cavajani <lcavajani@suse.com>