### PR TITLE
Set disk caching policy to "unsafe"

### DIFF
--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -181,6 +181,11 @@ resource "libvirt_domain" "admin" {
   }
 <% end -%>
 
+  # used to add disk -> cache="unsafe"
+  xml {
+    xslt = "${file("disk_caching.xsl")}"
+  }
+
   disk {
     volume_id = "${libvirt_volume.admin.id}"
   }
@@ -312,6 +317,11 @@ resource "libvirt_domain" "master" {
   }
 <% end -%>
 
+  # used to add disk -> cache="unsafe"
+  xml {
+    xslt = "${file("disk_caching.xsl")}"
+  }
+
   disk {
     volume_id = "${element(libvirt_volume.master.*.id, count.index)}"
   }
@@ -414,6 +424,11 @@ resource "libvirt_domain" "worker" {
   <% end -%>
   }
 <% end -%>
+
+  # used to add disk -> cache="unsafe"
+  xml {
+    xslt = "${file("disk_caching.xsl")}"
+  }
 
   disk {
     volume_id = "${element(libvirt_volume.worker.*.id, count.index)}"

--- a/caasp-kvm/disk_caching.xsl
+++ b/caasp-kvm/disk_caching.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="disk[@type='volume']/driver">
+    <xsl:copy>
+      <xsl:attribute name="cache">unsafe</xsl:attribute>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
The unsafe policy prevent fsync from KVM VMs to be executed by the hypervisor as well. It seems to be effective as a workaround to unexpectedly high disk write latencies.
It can lead to data loss in the VM in case of power failure on the hypervisor but this is not a concern for CI testbeds.