### PR TITLE
Use the unstable terraform repository.

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -261,8 +261,8 @@ setup() {
 
   if ! zypper lr -dU | grep --quiet "opensuse.org/repositories/systemsmanagement:/terraform:/unstable" ; then
     log "Adding systemsmanagement:terraform:unstable Zypper repo"
-    sudo zypper ar "http://download.opensuse.org/repositories/systemsmanagement:/terraform:/unstable/${dist}/systemsmanagement:terraform:unstable.repo"
-    sudo zypper --gpg-auto-import-keys ref systemsmanagement_terraform
+    sudo zypper ar -f "http://download.opensuse.org/repositories/systemsmanagement:/terraform:/unstable/${dist}/systemsmanagement:terraform:unstable.repo"
+    sudo zypper --gpg-auto-import-keys ref systemsmanagement_terraform_unstable
   fi
 
   sudo zypper in --no-confirm --auto-agree-with-licenses $DIST_PACKAGES

--- a/caasp-devenv
+++ b/caasp-devenv
@@ -259,9 +259,9 @@ setup() {
     sudo zypper --gpg-auto-import-keys ref Devel_CASP_CI
   fi
 
-  if ! zypper lr -dU | grep --quiet "opensuse.org/repositories/systemsmanagement:/terraform" ; then
-    log "Adding systemsmanagement:terraform Zypper repo"
-    sudo zypper ar "http://download.opensuse.org/repositories/systemsmanagement:/terraform/${dist}/systemsmanagement:terraform.repo"
+  if ! zypper lr -dU | grep --quiet "opensuse.org/repositories/systemsmanagement:/terraform:/unstable" ; then
+    log "Adding systemsmanagement:terraform:unstable Zypper repo"
+    sudo zypper ar "http://download.opensuse.org/repositories/systemsmanagement:/terraform:/unstable/${dist}/systemsmanagement:terraform:unstable.repo"
     sudo zypper --gpg-auto-import-keys ref systemsmanagement_terraform
   fi
 


### PR DESCRIPTION
The libvirt-provider from the stable terraform repository will not work with the
xml tags used in the terraform file.