### PR TITLE
Fix terraform variables

### DIFF
--- a/ses-openstack-terraform/ses-openstack
+++ b/ses-openstack-terraform/ses-openstack
@@ -25,7 +25,8 @@ USAGE:
   2. Edit openstack.tfvars file and provide following options
 
   * image_name - SLES OpenStack Image Name
-  * network_name - OpenStack Private Network
+  * internal_net - OpenStack Private Network Name
+  * external_net - OpenStack Public Network Name
   * admin_size - SES Admin OpenStack Flavour
   * master_size - SES Master OpenStack Flavour
   * worker_size - SES Worker OpenStack Flavour

--- a/suse-registry-mirror-openstack-terraform/suse-registry-mirror-openstack-terraform
+++ b/suse-registry-mirror-openstack-terraform/suse-registry-mirror-openstack-terraform
@@ -25,7 +25,8 @@ USAGE:
   2. Edit openstack.tfvars file and provide following options
 
   * image_name - SLES JEOS OpenStack Image Name
-  * network_name - OpenStack Private Network
+  * internal_net - OpenStack Private Network Name
+  * external_net - OpenStack Public Network Name
   * admin_size - SLES JEOS OpenStack Flavour
   * sles_base - sles base repo
   * sles_update - sles update repo


### PR DESCRIPTION
After playing around with the cluster I saw that the `network_name` variable does not exist any more and is now split up into `internal_net` and `external_net`.

I hope that is valid and would appreciate a short review.