### PR TITLE
caasp-kvm: undefine admin VM

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -400,6 +400,9 @@ destroy() {
   terraform init && \
     terraform destroy -force $TF_ARGS && \
     rm -f "$ENVIRONMENT"
+  # Sometimes terraform destroy leaves the admin VM behind, in shut off state,
+  # after a failed startup/build. Temporary workaround.
+  virsh undefine admin || true
 }
 
 [ -n "$ACTION" ] || usage


### PR DESCRIPTION
Perform a better cleanup with caasp-kvm --destroy
Terraform should be fixed to do the cleanup by itself. 