### PR TITLE
jenkins-jobs: job-template: Disable the codenarc test

### DIFF
--- a/jenkins-jobs/job-templates.yaml
+++ b/jenkins-jobs/job-templates.yaml
@@ -72,7 +72,7 @@
 - job-template:
     name: '{name}.codenarc'
     project-type: multibranch
-    disabled: '{obj:disabled}'
+    disabled: true
     periodic-folder-trigger: 1h
     number-to-keep: 30
     days-to-keep: 30


### PR DESCRIPTION
The codenarc test is only useful to run Groovy codying style checks
and it's currently failing to due disabled k8s integration so lets
disable it.