### PR TITLE
jenkins-jobs: Use the kubic-project jjb repository

### DIFF
--- a/jenkins-jobs/tox.ini
+++ b/jenkins-jobs/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 sitepackages = False
 
 deps =
-    git+https://github.com/kiall/jenkins-job-builder
+    git+https://github.com/kubic-project/jenkins-job-builder
 
 [testenv:test]
 commands =


### PR DESCRIPTION
kubic-project/automation needs a modified version of jjb so bring it
under our control until we manage to upstream all the patches.