### PR TITLE
Handle kubectl scale failures

### DIFF
--- a/k8s-pod-tests/k8s-pod-tests
+++ b/k8s-pod-tests/k8s-pod-tests
@@ -210,7 +210,13 @@ scale_pod_in_steps() {
       new_num=$NUM_REPLICAS
     fi
     echo "Setting replicas to $new_num"
-    kubectl scale --replicas=$new_num --kubeconfig="$KUBECONFIG_FN" deployment/$NAME
+    # Handle occasional kubectl scale failures e.g.:
+    # Operation cannot be fulfilled on deployments.extensions "default": the object has been modified
+    for retries in $(seq 1 10); do
+      kubectl scale --replicas=$new_num --kubeconfig="$KUBECONFIG_FN" deployment/$NAME && break
+      echo "[$retries / 10] kubectl scale failed. Retrying in 10 seconds..."
+      sleep 10
+    done
     [[ "$WAIT" = true ]] && wait_until_available_num $new_num $SCALESTEP_TIMEOUT
     current_num=$new_num
   done


### PR DESCRIPTION
Occasionally the master branch encountered the same error as in release 3.0
Already fixed in release 3.0 in #565 

```error: Scaling the resource failed with: could not update the scale for deployments.extensions default: Operation cannot be fulfilled on deployments.extensions "default": the object has been modified; please apply your changes to the latest version and try again; Current resource version 2749```
