### PR TITLE
Sets the qemu-agent variable to true if a bridge will be used.

### DIFF
--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -166,6 +166,11 @@ resource "libvirt_domain" "admin" {
   metadata  = "admin.${var.domain_name},admin,${count.index}"
   cloudinit = "${libvirt_cloudinit.admin.id}"
 
+
+<% if ENV['CAASP_BRIDGE'] != '' -%>
+  qemu-agent = true
+<% end -%>
+
   cpu {
     mode = "host-passthrough"
   }
@@ -297,6 +302,10 @@ resource "libvirt_domain" "master" {
   metadata   = "master-${count.index}.${var.domain_name},master,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 
+<% if ENV['CAASP_BRIDGE'] != '' -%>
+  qemu-agent = true
+<% end -%>
+
   cpu {
     mode = "host-passthrough"
   }
@@ -399,6 +408,10 @@ resource "libvirt_domain" "worker" {
   cloudinit  = "${element(libvirt_cloudinit.worker.*.id, count.index)}"
   metadata   = "worker-${count.index}.${var.domain_name},worker,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
+
+<% if ENV['CAASP_BRIDGE'] != '' -%>
+  qemu-agent = true
+<% end -%>
 
   cpu {
     mode = "host-passthrough"


### PR DESCRIPTION
When using bridge network configurations you need to enable the qemu_agent = true.
Otherwise you will not retrieve the ip adresses of domains.

Fixes #574

Signed-off-by: Jürgen Löhel <jloehel@suse.com>