### PR TITLE
Fix Issue #577: ruby bundler update

### DIFF
--- a/caasp-kvm/tools/build-velum-image
+++ b/caasp-kvm/tools/build-velum-image
@@ -90,7 +90,7 @@ build_fresh_image() {
                     bash -c "
                       cd /srv/velum-latest && \
                       mkdir -p /var/lib/velum && \
-                      gem install --no-ri --no-rdoc bundler -n /usr/bin && \
+                      gem install --no-ri --no-rdoc bundler -v 1.17.3 -n /usr/bin && \
                       bundle.${RUBY_VERSION} config --local frozen 0 && \
                       bundle.${RUBY_VERSION} config --local build.nokogiri --use-system-libraries && \
                       bundle.${RUBY_VERSION} install --deployment --binstubs=/usr/local/bin --path=/var/lib/velum && \


### PR DESCRIPTION
## What does this PR change?

After bundler was updated to 2.0.0 from rubygems.org in 01/03/2019, velum-development:0.0, which has ruby2.1 failed to install ruby bundler because new ruby bundler requires >= ruby2.3.0 and gem installation uses highest version if not specified.
After it failed installing bundler, it does not install any dependent gems on the velum image template.
This causes to fail to deploy static pods in admin node. And cluster build fails with "Waiting for Velum to initialize". So simple solution is locking the safe version on bundler.
