### PR TITLE
[release-2.1] adapt cloudinit api change to reflect upstream api

### DIFF
--- a/caasp-kvm/cluster.tf.erb
+++ b/caasp-kvm/cluster.tf.erb
@@ -140,7 +140,7 @@ resource "libvirt_volume" "admin" {
   base_volume_id = "${libvirt_volume.caasp_img.id}"
 }
 
-resource "libvirt_cloudinit" "admin" {
+resource "libvirt_cloudinit_disk" "admin" {
   name      = "${var.name_prefix}caasp_admin_cloud_init.iso"
   pool      = "${var.pool}"
   user_data = "${file("cloud-init/admin.cfg")}"
@@ -151,7 +151,7 @@ resource "libvirt_domain" "admin" {
   memory    = "${var.caasp_admin_memory}"
   vcpu      = "${var.caasp_admin_vcpu}"
   metadata   = "${var.name_prefix}caasp-admin.${var.caasp_domain_name},admin,${count.index}"
-  cloudinit = "${libvirt_cloudinit.admin.id}"
+  cloudinit = "${libvirt_cloudinit_disk.admin.id}"
 
   cpu {
     mode = "host-passthrough"
@@ -251,7 +251,7 @@ resource "libvirt_volume" "master" {
   count          = "${var.caasp_master_count}"
 }
 
-data "template_file" "master_cloud_init_user_data" {
+data "template_file" "master_cloud_init_disk_user_data" {
   # needed when 0 master nodes are defined
   count    = "${var.caasp_master_count}"
   template = "${file("cloud-init/master.cfg.tpl")}"
@@ -263,12 +263,12 @@ data "template_file" "master_cloud_init_user_data" {
   depends_on = ["libvirt_domain.admin"]
 }
 
-resource "libvirt_cloudinit" "master" {
+resource "libvirt_cloudinit_disk" "master" {
   # needed when 0 master nodes are defined
   count     = "${var.caasp_master_count}"
-  name      = "${var.name_prefix}caasp_master_cloud_init_${count.index}.iso"
+  name      = "${var.name_prefix}caasp_master_cloud_init_disk_${count.index}.iso"
   pool      = "${var.pool}"
-  user_data = "${element(data.template_file.master_cloud_init_user_data.*.rendered, count.index)}"
+  user_data = "${element(data.template_file.master_cloud_init_disk_user_data.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "master" {
@@ -276,7 +276,7 @@ resource "libvirt_domain" "master" {
   name       = "${var.name_prefix}caasp_master_${count.index}"
   memory     = "${var.caasp_master_memory}"
   vcpu       = "${var.caasp_master_vcpu}"
-  cloudinit  = "${element(libvirt_cloudinit.master.*.id, count.index)}"
+  cloudinit  = "${element(libvirt_cloudinit_disk.master.*.id, count.index)}"
   metadata   = "${var.name_prefix}caasp-master-${count.index}.${var.caasp_domain_name},master,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 
@@ -340,7 +340,7 @@ resource "libvirt_volume" "worker" {
   count          = "${var.caasp_worker_count}"
 }
 
-data "template_file" "worker_cloud_init_user_data" {
+data "template_file" "worker_cloud_init_disk_user_data" {
   # needed when 0 worker nodes are defined
   count    = "${var.caasp_worker_count}"
   template = "${file("cloud-init/worker.cfg.tpl")}"
@@ -352,12 +352,12 @@ data "template_file" "worker_cloud_init_user_data" {
   depends_on = ["libvirt_domain.admin"]
 }
 
-resource "libvirt_cloudinit" "worker" {
+resource "libvirt_cloudinit_disk" "worker" {
   # needed when 0 worker nodes are defined
   count     = "${var.caasp_worker_count}"
-  name      = "${var.name_prefix}caasp_worker_cloud_init_${count.index}.iso"
+  name      = "${var.name_prefix}caasp_worker_cloud_init_disk_${count.index}.iso"
   pool      = "${var.pool}"
-  user_data = "${element(data.template_file.worker_cloud_init_user_data.*.rendered, count.index)}"
+  user_data = "${element(data.template_file.worker_cloud_init_disk_user_data.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "worker" {
@@ -365,7 +365,7 @@ resource "libvirt_domain" "worker" {
   name       = "${var.name_prefix}caasp_worker_${count.index}"
   memory     = "${var.caasp_worker_memory}"
   vcpu       = "${var.caasp_worker_vcpu}"
-  cloudinit  = "${element(libvirt_cloudinit.worker.*.id, count.index)}"
+  cloudinit  = "${element(libvirt_cloudinit_disk.worker.*.id, count.index)}"
   metadata   = "${var.name_prefix}caasp-worker-${count.index}.${var.caasp_domain_name},worker,${count.index},${var.name_prefix}"
   depends_on = ["libvirt_domain.admin"]
 


### PR DESCRIPTION
(cherry-picked from 375fb0d5e6a27b217fe13976064cae9d01d69d80)

Signed-off-by: Maximilian Meister <mmeister@suse.de>

I know that this branch is out of maintenance, but this backport is needed to start a v2 cluster via terraform-libvirt nowadays