### PR TITLE
Use vanilla KVM in network emulation pipeline

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-network-emulation
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-network-emulation
@@ -21,7 +21,11 @@ properties([
     ])
 ])
 
+def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
+kvmTypeOptions.vanilla = true
+
 coreKubicProjectPeriodic(
+    environmentTypeOptions: kvmTypeOptions,
     environmentDestroy: env.ENVIRONMENT_DESTROY.toBoolean(),
     masterCount: env.MASTER_COUNT.toInteger(),
     workerCount: env.WORKER_COUNT.toInteger()


### PR DESCRIPTION
Make this pipeline consistent with the other ones.
To be backported to release-3.0