### PR TITLE
Switch injection from rm/cp to rsync

### DIFF
--- a/caasp-kvm/caasp-kvm
+++ b/caasp-kvm/caasp-kvm
@@ -346,8 +346,7 @@ build() {
 
     log "Copying CaaSP Container Manifests"
     local injected="$(realpath injected-caasp-container-manifests)"
-    rm -rf $injected/*
-    cp -r $CAASP_MANIFESTS_DIR/* "$injected/"
+    rsync -ai --exclude '.**' --delete "$CAASP_MANIFESTS_DIR/" "${injected:?}/"
 
     log "Patching Container Manifests"
     $DIR/tools/fix-kubelet-manifest ${SLE15_MANIFEST_FLAG:-} ${KUBIC_MANIFEST_FLAG:-} -o $injected/manifests/public.yaml $injected/manifests/public.yaml


### PR DESCRIPTION
## What does this PR change?

Use `rsync --delete` to keep kvm's injected manifests directory in sync instead of `rm * %% cp -a *`.  Uses `--exclude .git**` to exclude dotfiles and directories like the original intended, but this also recursively excludes those git-related dot files (so, the .gitignore in subdirectories and similar things that don't need to be copied) while still potentially allowing other "hidden" files if needed in the future.  It also uses `-i` so only the changes are logged.

Additionally use bash's `${var:?} structure to cause the script to fail in the exceedingly unlikely event that the target directory var is undefined or empty, because if that happened, we would've started deleting at `/` (eek).

## Backport to other branches
Use  `git cherry-pick` backport a commit from master to branches

- [ false ] release-2.1 
- [ false ] release-3.0


