### PR TITLE
velum-bootstrap: check content disposition instead of url

### DIFF
--- a/velum-bootstrap/spec/features/03-download-kubeconfig.rb
+++ b/velum-bootstrap/spec/features/03-download-kubeconfig.rb
@@ -43,17 +43,17 @@ feature "Download Kubeconfig" do
     expect(page).to have_text("You will see a download dialog")
     puts "<<< User is redirected back to velum"
 
+    puts ">>> User sees a download button to download file if neeeded"
+    expect(page).to have_text("Click here if the download has not started automatically.")
+    puts "<<< User sees a download button to download file if neeeded"
+
     puts ">>> User is prompted to download the kubeconfig"
-    download_uri = URI(page.html.match(/window\.location\.href = "(.*?)"/).captures[0])
-
-    http = Net::HTTP.new(download_uri.host, download_uri.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-    request = Net::HTTP::Get.new(download_uri.request_uri)
-    response = http.request(request)
-
-    File.write("kubeconfig", response.body)
+    content_disposition = page.response_headers["Content-Disposition"]
+    expect(content_disposition).to eq("attachment; filename=kubeconfig")
     puts "<<< User is prompted to download the kubeconfig"
+
+    # poltergeist doesn't download the file itself so we need to download
+    # the file manually in order to make the other tests pass
+    download_kubeconfig
   end
 end

--- a/velum-bootstrap/spec/support/helpers.rb
+++ b/velum-bootstrap/spec/support/helpers.rb
@@ -26,6 +26,31 @@ module Helpers
     puts "<<< User logged in"
   end
 
+  def download_kubeconfig
+    # TODO: remove in the future when POST gets deployed
+    matches = page.html.match(/window\.location\.href = "(.*?)"/)
+
+    download_uri = if matches.nil?
+      URI(page.html.match(/action="(.*?)"/).captures[0])
+    else
+      URI(matches.captures[0])
+    end
+
+    http = Net::HTTP.new(download_uri.host, download_uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    request = if page.has_css?("form")
+      Net::HTTP::Post.new(download_uri.request_uri)
+    else
+      # TODO: remove in the future when POST gets deployed
+      Net::HTTP::Get.new(download_uri.request_uri)
+    end
+    response = http.request(request)
+
+    File.write("kubeconfig", response.body)
+  end
+
   def default_interface
     `awk '$2 == 00000000 { print $1 }' /proc/net/route`.strip
   end
@@ -33,7 +58,6 @@ module Helpers
   def default_ip_address
     `ip addr show #{default_interface} | awk '$1 == "inet" {print $2}' | cut -f1 -d/`.strip
   end
-
 end
 
 RSpec.configure { |config| config.include Helpers, type: :feature }


### PR DESCRIPTION
The spec for checking the kubeconfig download was previously done
through checking an url associated with the automatic download.

A better way of checking the autoamtic download is to check the
content disposition in the response header.