### PR TITLE
[k8s 1.13] Fix case for items in the new k8s

### DIFF
--- a/testinfra/tests/test_kubernetes_master.py
+++ b/testinfra/tests/test_kubernetes_master.py
@@ -84,13 +84,13 @@ class TestKubernetesMaster(object):
         )
 
         env = TestUtils.environment()
-        assert (len(nodes["Items"]) == sum(1 for i in env["minions"] if i["role"] != "admin" and i["status"] == "bootstrapped"))
+        assert (len(nodes["items"]) == sum(1 for i in env["minions"] if i["role"] != "admin" and i["status"] == "bootstrapped"))
 
         # Check all nodes are marked as "Ready" in k8s
-        for node in nodes["Items"]:
-            for item in node["Status"]["Conditions"]:
-                if item["Type"] is "Ready":
-                    assert bool(item["Status"])
+        for node in nodes["items"]:
+            for item in node["status"]["conditions"]:
+                if item["type"] is "Ready":
+                    assert bool(item["status"])
 
     @pytest.mark.bootstrapped
     def test_salt_id(self, host):


### PR DESCRIPTION
After deploying the new k8s version our infratests are failing at
the part where is parses nodes.json. The fix is very simple,
replacing 'Items' with 'items'.

## What does this PR change?

Previous bevarior:

```
============================================================== FAILURES ===============================================================
_________________________ TestKubernetesMaster.test_kubernetes_cluster[ssh://master-0.devenv.caasp.suse.net] __________________________

self = <tests.test_kubernetes_master.TestKubernetesMaster object at 0x7fb097ebfa10>
host = <testinfra.host.Host object at 0x7fb098008910>

    @pytest.mark.bootstrapped
    def test_kubernetes_cluster(self, host):
        host.run(
            "kubectl cluster-info dump --output-directory=/tmp/cluster_info"
        )
    
        nodes = json.loads(
            host.file("/tmp/cluster_info/nodes.json").content_string
        )
    
        env = TestUtils.environment()
>       assert (len(nodes["Items"]) == sum(1 for i in env["minions"] if i["role"] != "admin" and i["status"] == "bootstrapped"))
E       KeyError: 'Items'

tests/test_kubernetes_master.py:87: KeyError
========================================================= 24 tests deselected =========================================================
=================================== 1 failed, 16 passed, 2 skipped, 24 deselected in 13.01 seconds ====================================
ERROR: InvocationError for command '/usr/bin/sh /home/tux/github/automation/testinfra/tools/testAllRoles.sh /home/tux/github/automation/caasp-kvm/environment.json /home/tux/github/automation/testinfra/../misc-tools/environment.ssh_config' (exited with code 1)
_______________________________________________________________ summary _______________________________________________________________
ERROR:   all: commands failed
```

Current Behavior:

It works without error.

## Backport to other branches
Use  `git cherry-pick` backport a commit from master to branches

- [ ] release-2.1 
- [ ] release-3.0

## Documentation

## Links

Fixes #
Tracks # **add downstream PR, if any**
