### PR TITLE
Jenkinsfile.codenarc: Use docker cmdline directly instead of k8s Jenkins plugin

### DIFF
--- a/Jenkinsfile.codenarc
+++ b/Jenkinsfile.codenarc
@@ -10,34 +10,18 @@ githubCollaboratorCheck(
     user: env.CHANGE_AUTHOR,
     credentialsId: 'github-token')
 
-def label = "salt-automation-${UUID.randomUUID().toString()}"
+node("leap15.0&&caasp-pr-worker") {
+    stage('Retrieve Code') {
+         checkout scm
+    }
 
-podTemplate(label: label, containers: [
-        containerTemplate(
-            name: 'codenarc',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-codenarc-container:latest',
-            alwaysPullImage: true,
-            ttyEnabled: true,
-            command: 'cat',
-            envVars: [
-                envVar(key: 'http_proxy', value: env.http_proxy),
-                envVar(key: 'https_proxy', value: env.http_proxy),
-            ],
-        ),
-]) {
-    node(label) {
-        stage('Retrieve Code') {
-            checkout scm
-        }
-
+    docker.image('registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-codenarc-container:latest').inside('-v ${WORKSPACE}:/codenarc') {
         stage('Style Checks') {
-            container('codenarc') {
-                try {
-                    sh 'java -classpath /groovy-all-2.4.6.jar:/CodeNarc-1.1.jar:/slf4j-api-1.7.25.jar:/slf4j-simple-1.7.25.jar org.codenarc.CodeNarc -report=html -report=xml -basedir=jenkins-pipelines'
-                } finally {
-                    archiveArtifacts(artifacts: "CodeNarcReport.html", fingerprint: true)
-                    warningsCodeNarc(filename: 'CodeNarcXmlReport.xml')
-                }
+            try {
+                sh(script: "java -classpath /groovy-all-2.4.6.jar:/CodeNarc-1.1.jar:/slf4j-api-1.7.25.jar:/slf4j-simple-1.7.25.jar org.codenarc.CodeNarc -report=html -report=xml -basedir=/codenarc/jenkins-pipelines")
+            } finally {
+                archiveArtifacts(artifacts: "CodeNarcReport.html", fingerprint: true)
+                warningsCodeNarc(filename: 'CodeNarcXmlReport.xml')
             }
         }
     }

--- a/Jenkinsfile.jenkins-jobs
+++ b/Jenkinsfile.jenkins-jobs
@@ -10,43 +10,20 @@ githubCollaboratorCheck(
     user: env.CHANGE_AUTHOR,
     credentialsId: 'github-token')
 
-def label = "automation-jenkins-jobs-${UUID.randomUUID().toString()}"
+node("leap15.0&&caasp-pr-worker") {
+    stage('Retrieve Code') {
+         checkout scm
+    }
 
-podTemplate(label: label, containers: [
-        containerTemplate(
-            name: 'tox',
-            image: 'registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest',
-            alwaysPullImage: true,
-            ttyEnabled: true,
-            command: 'cat',
-            envVars: [
-                envVar(key: 'http_proxy', value: env.http_proxy),
-                envVar(key: 'https_proxy', value: env.http_proxy),
-            ],
-        ),
-]) {
-    node(label) {
-        stage('Retrieve Code') {
-            checkout scm
-        }
-
+    docker.image('registry.suse.de/devel/casp/ci/opensuse_leap_42.3_containers/jenkins-tox-container:latest').inside('-v ${WORKSPACE}:/jenkins-jobs') {
         stage('Test') {
-            container('tox') {
-                dir('jenkins-jobs') {
-                    sh 'tox -e test'
-                }
-            }
+            sh 'cd /jenkins-jobs/jenkins-jobs; tox -e test'
         }
-
         // If this is NOT a Pull Request build...
         if (!env.CHANGE_ID) {
             stage('Update') {
-                container('tox') {
-                    dir('jenkins-jobs') {
-                        withCredentials([file(credentialsId: 'jenkins-job-builder-config', variable: 'JJB_CONFIG')]) {
-                            sh(script: "tox -e update -- --conf ${JJB_CONFIG}")
-                        }
-                    }
+                withCredentials([file(credentialsId: 'jenkins-job-builder-config', variable: 'JJB_CONFIG')]) {
+                    sh(script: "cd /jenkins-jobs/jenkins-jobs; tox -e update -- --conf ${JJB_CONFIG}")
                 }
             }
         }


### PR DESCRIPTION
The codenarc pipeline is the only one which depends on the k8s Jenkins
plugin. As such, we can use docker directly in order to be able to drop
the plugin from the server.

## What does this PR change?
- Unnecessary dependency to k8s JK plugin
- Uses docker cmd directly

## Backport to other branches
Use  `git cherry-pick` backport a commit from master to branches

- [ X] release-3.0

This will need backport to release-3.0 branch once it's green