### PR TITLE
[3.0] velum-bootstrap: check content disposition instead of url

### DIFF
--- a/velum-bootstrap/spec/features/03-download-kubeconfig.rb
+++ b/velum-bootstrap/spec/features/03-download-kubeconfig.rb
@@ -44,17 +44,17 @@ feature "Download Kubeconfig" do
     expect(page).to have_text("You will see a download dialog")
     puts "<<< User is redirected back to velum"
 
+    puts ">>> User sees a download button to download file if neeeded"
+    expect(page).to have_text("Click here if the download has not started automatically.")
+    puts "<<< User sees a download button to download file if neeeded"
+
     puts ">>> User is prompted to download the kubeconfig"
-    download_uri = URI(page.html.match(/window\.location\.href = "(.*?)"/).captures[0])
-
-    http = Net::HTTP.new(download_uri.host, download_uri.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-    request = Net::HTTP::Get.new(download_uri.request_uri)
-    response = http.request(request)
-
-    File.write("kubeconfig", response.body)
+    content_disposition = page.response_headers["Content-Disposition"]
+    expect(content_disposition).to eq("attachment; filename=kubeconfig")
     puts "<<< User is prompted to download the kubeconfig"
+
+    # poltergeist doesn't download the file itself so we need to download
+    # the file manually in order to make the other tests pass
+    download_kubeconfig
   end
 end


### PR DESCRIPTION
The spec for checking the kubeconfig download was previously done
through checking an url associated with the automatic download.

A better way of checking the automatic download is to check the
content disposition in the response header.

The previous behavior to manually download kubeconfig was maintained in
order to use the kubeconfig in further tests. The only difference is
that is compatible with both GET and POST requests due to different
versions in different repos. In the future we can remove the GET and
keep only the POST one.

(cherry picked from commit 3a1afa4127ff2caa303057817e63ab3a92aa7a90)

Backport of #592 