### PR TITLE
[3.0] Add a specific scaling pipeline

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kube-scaling-nightly
+++ b/jenkins-pipelines/Jenkinsfile.kube-scaling-nightly
@@ -5,27 +5,23 @@ properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
     pipelineTriggers([cron('H H(3-5) * * *')]),
+    parameters([
+        booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?')
+    ]),
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();
 kvmTypeOptions.vanilla = true
 
 coreKubicProjectPeriodic(
-    environmentTypeOptions: kvmTypeOptions
+    environmentTypeOptions: kvmTypeOptions,
+    environmentDestroy: env.ENVIRONMENT_DESTROY.toBoolean(),
 ) {
     // empty preBootstrapBody
 } {
-    // Run through the upgrade orchestration
-    upgradeEnvironmentStage1(
-        environment: environment,
-        fakeUpdatesAvailable: true
-    )
-
-    upgradeEnvironmentStage2(
-        environment: environment
-    )
-
-    coreKubicProjectNodeTests(
-        environment: environment
+    coreKubicProjectClusterTests(
+      podName: 'default',
+      replicaCount: 15,
+      replicasCreationIntervalSeconds: 600
     )
 }

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-bare-metal
@@ -32,9 +32,7 @@ coreKubicProjectPeriodic(
         environment: environment
     )
 
-    // Run the Core Project Tests again
-    coreKubicProjectTests(
-        environment: environment,
-        podName: 'default'
+    coreKubicProjectNodeTests(
+        environment: environment
     )
 }

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-network-emulation
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-network-emulation
@@ -34,10 +34,8 @@ coreKubicProjectPeriodic(
       sh(script: "./automation/misc-tools/network-emulation setup all --env-json-path ${WORKSPACE}/environment.json -l ${WORKSPACE}/logs/netem-setup.log --latency ${LATENCY} --jitter ${JITTER} --packet-loss ${PACKET_LOSS} --duplication ${DUPLICATION} --corruption ${CORRUPTION} --bandwidth ${BANDWIDTH}")
     }
 
-    // Run the Core Project Tests again
-    coreKubicProjectTests(
-        environment: environment,
-        podName: 'default'
+    coreKubicProjectNodeTests(
+        environment: environment
     )
 
     stage('Remove Network Emulation') {

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-add
@@ -31,10 +31,8 @@ coreKubicProjectPeriodic(
         )
     }
 
-    // Run the Core Project Tests again
-    coreKubicProjectTests(
-        environment: environment,
-        podName: 'default'
+    coreKubicProjectNodeTests(
+        environment: environment
     )
 
     return environment

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-remove
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-node-remove
@@ -22,10 +22,8 @@ coreKubicProjectPeriodic(
         )
     }
 
-    // Run the Core Project Tests again
-    coreKubicProjectTests(
-        environment: environment,
-        podName: 'default'
+    coreKubicProjectNodeTests(
+        environment: environment
     )
 
     return environment

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack
@@ -44,10 +44,8 @@ lock('openstack-single-user') {
             environment: environment
         )
 
-        // Run the Core Project Tests again
-        coreKubicProjectTests(
-            environment: environment,
-            podName: 'default'
+        coreKubicProjectNodeTests(
+            environment: environment
         )
     }
 }

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -45,9 +45,7 @@ coreKubicProjectPeriodic(
        environment: environment
     )
 
-    // Run the Core Project Tests again
-    coreKubicProjectTests(
-        environment: environment,
-        podName: 'default'
+    coreKubicProjectNodeTests(
+        environment: environment
     )
 }

--- a/jenkins-pipelines/Jenkinsfile.kubic-sandbox
+++ b/jenkins-pipelines/Jenkinsfile.kubic-sandbox
@@ -34,10 +34,8 @@ coreKubicProjectPeriodic(
         environment: environment
     )
 } {
-    // Run the Core Project Tests again
-    coreKubicProjectTests(
-        environment: environment,
-        podName: 'default'
+    coreKubicProjectNodeTests(
+        environment: environment
     )
 
     if (env.RUN_CONFORMANCE_TESTS.toBoolean()) {


### PR DESCRIPTION
This job will run the pod scaling tests in a nightly basis.

Remove the scaling tests from the rest of the pipelines.

Backported from https://github.com/kubic-project/automation/pull/614