### PR TITLE
misc-tools: upload-image-openstack: Only remove image if a new one was added

### DIFF
--- a/misc-tools/upload-image-openstack.sh
+++ b/misc-tools/upload-image-openstack.sh
@@ -13,16 +13,21 @@ IMAGE_NAME="CaaSP-${CHANNEL}-${IMAGE_VERSION}-${IMAGE_BUILD}"
 source $OPENRC
 echo "[+] Checking if we already have this image: $IMAGE_NAME"
 
-if [[ $(openstack image list -c ID -f value --property caasp-version="${IMAGE_VERSION}" --property caasp-channel="${CHANNEL}" --property caasp-build="${IMAGE_BUILD}") != "" ]]; then
-    echo "[+] Deleting previous SUSE CaaSP qcow2 VM image for {version=$IMAGE_VERSION, channel=$CHANNEL}"
-    for images in $(openstack image list -c ID -f value --property caasp-version="${IMAGE_VERSION}" --property caasp-channel="${CHANNEL}"); do
-        openstack image delete $images
-    done
+if [[ $(openstack image list -c ID -f value --property caasp-version="${IMAGE_VERSION}" --property caasp-channel="${CHANNEL}" --property caasp-build="${IMAGE_BUILD}") == "" ]]; then
     echo "[+] Uploading SUSE CaaSP qcow2 VM image: $IMAGE_NAME"
-    openstack image create $IMAGE_NAME --private --disk-format qcow2 --container-format bare --min-disk 40 --file $IMAGE_FILENAME \
+    if openstack image create $IMAGE_NAME --private --disk-format qcow2 --container-format bare --min-disk 40 --file $IMAGE_FILENAME \
         --property caasp-version="$IMAGE_VERSION" \
         --property caasp-build="$IMAGE_BUILD" \
-        --property caasp-channel="$CHANNEL"
+        --property caasp-channel="$CHANNEL"; then
+        echo "[+] Deleting previous SUSE CaaSP qcow2 VM image for {version=$IMAGE_VERSION, channel=$CHANNEL}"
+        for image in $(openstack image list -c Name -f value --property caasp-version="${IMAGE_VERSION}" --property caasp-channel="${CHANNEL}"); do
+            [[ $image == $IMAGE_NAME ]] && continue
+            openstack image delete $images
+        done
+    else
+        echo "Failed to upload new image ${IMAGE_NAME}"
+        exit 1
+    fi
 else
    echo "[+] Skipping upload, we already have this image"
 fi


### PR DESCRIPTION
In order to minimize the possibility to run into a situation where a
previous image was removed but a new one was not uploaded we need to
play safe here and do the removal in the final step.