### PR TITLE
[3.0] Consistent minion id naming

### DIFF
--- a/caasp-bare-metal/deployer/environment_json.py
+++ b/caasp-bare-metal/deployer/environment_json.py
@@ -31,7 +31,7 @@ def create_environment_json(admin_host_ipaddr, available_hosts):
         name, hw_serial, macaddr, ipaddr, machine_id = minion
         d["minions"].append({
            "minionId" : machine_id,
-           "index" : idx,
+           "index" : str(indexes[role]),
            "fqdn" : hw_serial,
            "addresses" : {
               "privateIpv4" : ipaddr,

--- a/caasp-hyperv/tools/generate-environment
+++ b/caasp-hyperv/tools/generate-environment
@@ -34,7 +34,7 @@ echo $out
 
 for node in $(echo "$out" | jq -r '.minions[] | select(.["minion_id"]? == null) | [.addresses.publicIpv4] | join(" ")'); do
     machine_id=$(ssh root@$node $SSH_ARGS cat /etc/machine-id)
-    out=$(echo "$out" | jq ".minions | map(if (.addresses.publicIpv4 == \"$node\") then . + {\"minionID\": \"$machine_id\"} else . end) | {minions: .}")
+    out=$(echo "$out" | jq ".minions | map(if (.addresses.publicIpv4 == \"$node\") then . + {\"minionId\": \"$machine_id\"} else . end) | {minions: .}")
 done
 
 master=$(echo "$out" | jq -r '[.minions[] | select(.role=="master")] | .[0] | .fqdn')

--- a/caasp-kvm/tools/generate-environment
+++ b/caasp-kvm/tools/generate-environment
@@ -33,7 +33,7 @@ out=$(cat $TF_STATE | \
 
 for node in $(echo "$out" | jq -r '.minions[] | select(.["minion_id"]? == null) | [.addresses.publicIpv4] | join(" ")'); do
     machine_id=$(ssh root@$node $SSH_ARGS cat /etc/machine-id)
-    out=$(echo "$out" | jq ".minions | map(if (.addresses.publicIpv4 == \"$node\") then . + {\"minionID\": \"$machine_id\"} else . end) | {minions: .}")
+    out=$(echo "$out" | jq ".minions | map(if (.addresses.publicIpv4 == \"$node\") then . + {\"minionId\": \"$machine_id\"} else . end) | {minions: .}")
     fqdn=$(echo $out | jq -r ".minions[] | select(.addresses.publicIpv4 == \"$node\") | .fqdn")
     ip=$(dig +short $fqdn)
     # only set the reverse DNS as fqdn if the old fqdn does not resolve to the node IP

--- a/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
+++ b/velum-bootstrap/spec/features/02-bootstrap-cluster.rb
@@ -3,7 +3,7 @@ require "yaml"
 
 feature "Boostrap cluster" do
   let(:hostnames) { environment["minions"].map { |m| m["fqdn"] if m["role"] != "admin" }.compact }
-  let(:minion_ids) { environment["minions"].map { |m| m["minionId"] if m["role"] != "admin" }.compact }
+  let(:minion_ids) { environment["minions"].map { |m| m["minionId"] }.compact }
 
   before(:each) do
     unless self.inspect.include? "User registers"
@@ -87,7 +87,7 @@ feature "Boostrap cluster" do
     with_screenshot(name: :select_minion_roles) do
       environment["minions"].each do |minion|
         if ["master", "worker"].include?(minion["role"])
-          within("tr", text: minion["minionId"] || minion["minionID"]) do
+          within("tr", text: minion["minionId"]) do
             find(".#{minion["role"]}-btn").click
           end
         end

--- a/velum-bootstrap/spec/features/06-node-add.rb
+++ b/velum-bootstrap/spec/features/06-node-add.rb
@@ -58,12 +58,12 @@ feature "Add a Node" do
     with_screenshot(name: :select_new_minion_roles) do
       environment["minions"].each do |minion|
         # skip all minions that have been assigned already
-        unless page.text.include? minion["minionID"]
+        unless page.text.include? minion["minionId"]
           new_nodes_count -= 1
           next
         end
         if ["master", "worker"].include?(minion["role"])
-          within("tr", text: minion["minionId"] || minion["minionID"]) do
+          within("tr", text: minion["minionId"]) do
             find(".#{minion["role"]}-btn").click
           end
         end

--- a/velum-bootstrap/spec/spec_helper.rb
+++ b/velum-bootstrap/spec/spec_helper.rb
@@ -36,7 +36,7 @@ end
 def set_minion_status(minion_id, status)
   env = JSON.parse(File.read(environment_path))
   updated_minions = env["minions"].each do |m|
-    m["minionID"] == minion_id && m["status"] = status
+    m["minionId"] == minion_id && m["status"] = status
   end
   env["minions"] = updated_minions
   env


### PR DESCRIPTION
Minion id had inconsistent naming `minionID` and `minionId`, and this
can lead to errors and unexpected behavior.

(cherry picked from commit 7314757)