### PR TITLE
Retry sonobuoy retrieve

### DIFF
--- a/k8s-e2e-tests/e2e-tests
+++ b/k8s-e2e-tests/e2e-tests
@@ -8,6 +8,7 @@ SONOBUOY_RUN_ARGS=()
 SONOBUOY_IMAGE="gcr.io/heptio-images/sonobuoy"
 SONOBUOY_VERSION="latest"
 E2E_WAIT_TIME=${E2E_WAIT_TIME:-120} # How long to wait for the test to finish in minutes
+RETRIEVE_RETRIES=${RETRIEVE_RETRIES:-10}
 
 USAGE=$(cat <<USAGE
 Usage:
@@ -111,7 +112,18 @@ EOF
         # Create the artifacts path
         mkdir -p $ARTIFACTS_PATH
         # Copy results from the container
-        sonobuoy retrieve $ARTIFACTS_PATH
+        current_retries=0
+        while [ $current_retries -lt $RETRIEVE_RETRIES ]; do
+            if sonobuoy retrieve $ARTIFACTS_PATH; then
+                break
+            else
+                current_retries=$(($current_retries + 1))
+                sleep 5
+            fi
+        done
+        if [ $current_retries -eq $RETRIEVE_RETRIES ]; then
+            abort "Could not retrieve sonobuoy results"
+        fi
         # Extract conformance tests tarball results
         tar -xzf ${ARTIFACTS_PATH}/*_sonobuoy_*.tar.gz -C ${ARTIFACTS_PATH}/
     elif sonobuoy status | grep "Sonobuoy is still running"; then


### PR DESCRIPTION
Sometimes sonobuoy retrieve does not work, retry the retrieve command.

(cherry picked from commit 9435faa2ad4a4ef7de9375b3ee4102f759952258)

Backport of https://github.com/kubic-project/automation/pull/626