### PR TITLE
Improve Openstack terraform support

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -34,6 +34,7 @@ VANILLA=${CAASP_VANILLA:-}
 DISABLE_MELTDOWN_SPECTRE=${CAASP_DISABLE_MELTDOWN_SPECTRE:-}
 PROXY=${CAASP_HTTP_PROXY:-}
 LOCATION=${CAASP_LOCATION:-}
+OPENRC=${OPENRC:-}
 PARALLELISM=${CAASP_PARALLELISM:-1}
 ENABLE_TILLER=${CAASP_ENABLE_TILLER:-false}
 EXTRA_REPO=${CAASP_EXTRA_REPO:-}
@@ -100,6 +101,7 @@ Usage:
 
   * Common options
 
+    --openrc                         openRC file (only for OpenStack platforms)
     -p|--parallelism                 Set terraform parallelism (Default: CAASP_PARALLELISM)
     -P|--proxy                       Set HTTP Proxy (Default: CAASP_HTTP_PROXY)
     -L|--location                    Set location used for downloads (Default: CAASP_LOCATION or 'default')
@@ -166,7 +168,7 @@ in_array() {
     return $_found
 }
 
-OPTS=$(getopt -o Bbdhi:L:m:P:p:T:uw: --long build,bootstrap,destroy,disable-meltdown-spectre-fixes,enable-tiller,extra-repo:,help,location,parallelism:,plan,platform:,proxy:,setup,testinfra:,vanilla -n "$0" -- "$@")
+OPTS=$(getopt -o Bbdhi:L:m:P:p:T:uw: --long build,bootstrap,destroy,disable-meltdown-spectre-fixes,enable-tiller,extra-repo:,help,location,parallelism:,openrc,plan,platform:,proxy:,setup,testinfra:,vanilla -n "$0" -- "$@")
 eval set -- "$OPTS"
 
 # parse options
@@ -236,6 +238,10 @@ while true; do
       EXTRA_REPO="$2"
       shift 2
       ;;
+    --openrc)
+      OPENRC="$2"
+      shift 2
+      ;;
     --plan)
       ACTION=1
       RUN_PLAN=1
@@ -276,6 +282,7 @@ CAASP_PLATFORM_ARGS="-m $MASTERS -w $WORKERS --image $IMAGE"
 [ -n "$VANILLA"     ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --vanilla"
 [ -n "$DISABLE_MELTDOWN_SPECTRE" ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --disable-meltdown-spectre-fixes"
 [ -n "$EXTRA_REPO"  ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --extra-repo $EXTRA_REPO"
+[ -n "$OPENRC" ] && [[ $PLATFORM =~ openstack ]] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --openrc $OPENRC"
 
 export ENVIRONMENT="$DIR/$PLATFORM/environment.json"
 

--- a/caasp-devenv
+++ b/caasp-devenv
@@ -70,16 +70,16 @@ Usage:
 
   * Setup your workstation
 
-    --setup                     Install Dev Env Dependencies
+    --setup                          Install Dev Env Dependencies
 
   * Building a cluster
 
     -b|--build                       Run the CaaSP KVM Build Step
-    -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS)
-    -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS)
-    -u|--update-deployment           Update Terraform deployment (Default: false)
     -d|--destroy                     Run the CaaSP KVM Destroy Step
     -i|--image                       Image to use (Default: CAASP_IMAGE)
+    -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS)
+    -u|--update-deployment           Update Terraform deployment (Default: false)
+    -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS)
     --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
     --disable-meltdown-spectre-fixes Disable meltdown and spectre fixes (Default: false)
     --enable-tiller                  Enable Helm Tiller
@@ -89,22 +89,22 @@ Usage:
     Velum Username: test@test.com
     Velum Password: password
 
-    -B|--bootstrap              Bootstrap CaaSP cluster
+    -B|--bootstrap                   Bootstrap CaaSP cluster
 
   * Testing a cluster
 
-    -T|--testinfra              Run testinfra tests
+    -T|--testinfra                   Run testinfra tests
 
   * Common options
 
-    -p|--parallelism            Set terraform parallelism (Default: CAASP_PARALLELISM)
-    -P|--proxy                  Set HTTP Proxy (Default: CAASP_HTTP_PROXY)
-    -L|--location               Set location used for downloads (Default: CAASP_LOCATION or 'default')
+    -p|--parallelism                 Set terraform parallelism (Default: CAASP_PARALLELISM)
+    -P|--proxy                       Set HTTP Proxy (Default: CAASP_HTTP_PROXY)
+    -L|--location                    Set location used for downloads (Default: CAASP_LOCATION or 'default')
 
   * Advanced Options
 
-    --plan                      Run the CaaSP KVM Plan Step
-    --extra-repo <STR>          URL of a custom repository on the master(s)/worker(s) (Default: CAASP_EXTRA_REPO)
+    --plan                           Run the CaaSP KVM Plan Step
+    --extra-repo <STR>               URL of a custom repository on the master(s)/worker(s) (Default: CAASP_EXTRA_REPO)
 
   * Examples:
 
@@ -150,84 +150,99 @@ clone_needed_github_repos() {
   popd
 } 
 
+OPTS=$(getopt -o Bbdhi:L:m:P:p:T:uw: --long build,bootstrap,destroy,disable-meltdown-spectre-fixes,enable-tiller,extra-repo:,help,location,parallelism:,plan,proxy:,setup,testinfra:,vanilla -n "$0" -- "$@")
+OPTS=$(getopt -o Bbdhi:L:m:P:p:T:uw: --long build,bootstrap,destroy,disable-meltdown-spectre-fixes,enable-tiller,extra-repo:,help,location,parallelism:,plan,platform:,proxy:,setup,testinfra:,vanilla -n "$0" -- "$@")
+eval set -- "$OPTS"
 
 # parse options
-while [[ $# > 0 ]] ; do
+while true; do
   case $1 in
-    --setup)
+    -B|--bootstrap)
       ACTION=1
-      RUN_SETUP=1
+      RUN_BOOTSTRAP=1
+      shift
       ;;
     -b|--build)
       ACTION=1
       RUN_BUILD=1
-      ;;
-    -m|--masters)
-      MASTERS="$2"
-      shift
-      ;;
-    -w|--workers)
-      WORKERS="$2"
       shift
       ;;
     -d|--destroy)
       ACTION=1
       RUN_DESTROY=1
-      ;;
-    -u|--update-deployment)
-      ACTION=1
-      RUN_UPDATE_DEPLOYMENT=1
-      ;;
-    -i|--image)
-      IMAGE="$2"
-      shift
-      ;;
-    --vanilla)
-      VANILLA="true"
-      ;;
-    --disable-meltdown-spectre-fixes)
-      DISABLE_MELTDOWN_SPECTRE="true"
-      ;;
-    --enable-tiller)
-      ENABLE_TILLER=true
-      ;;
-    -B|--bootstrap)
-      ACTION=1
-      RUN_BOOTSTRAP=1
-      ;;
-    -T|--testinfra)
-      ACTION=1
-      RUN_TESTINFRA=1
-      ;;
-    -p|--parallelism)
-      PARALLELISM="$2"
-      shift
-      ;;
-    -P|--proxy)
-      PROXY="$2"
-      shift
-      ;;
-    -L|--location)
-      LOCATION="$2"
-      shift
-      ;;
-    --plan)
-      ACTION=1
-      RUN_PLAN=1
-      ;;
-    --extra-repo)
-      EXTRA_REPO="$2"
       shift
       ;;
     -h|--help)
       usage
       ;;
+    -i|--image)
+      IMAGE="$2"
+      shift 2
+      ;;
+    -L|--location)
+      LOCATION="$2"
+      shift 2
+      ;;
+    -m|--masters)
+      MASTERS="$2"
+      shift 2
+      ;;
+    -P|--proxy)
+      PROXY="$2"
+      shift 2
+      ;;
+    -p|--parallelism)
+      PARALLELISM="$2"
+      shift 2
+      ;;
+    -T|--testinfra)
+      ACTION=1
+      RUN_TESTINFRA=1
+      shift
+      ;;
+    -u|--update-deployment)
+      ACTION=1
+      RUN_UPDATE_DEPLOYMENT=1
+      shift
+      ;;
+    -w|--workers)
+      WORKERS="$2"
+      shift 2
+      ;;
+    --disable-meltdown-spectre-fixes)
+      DISABLE_MELTDOWN_SPECTRE="true"
+      shift
+      ;;
+    --enable-tiller)
+      ENABLE_TILLER=true
+      shift
+      ;;
+    --extra-repo)
+      EXTRA_REPO="$2"
+      shift 2
+      ;;
+    --plan)
+      ACTION=1
+      RUN_PLAN=1
+      shift
+      ;;
+    --setup)
+      ACTION=1
+      RUN_SETUP=1
+      shift
+      ;;
+    --vanilla)
+      VANILLA="true"
+      ;;
+    --)
+      shift
+      break
+      ;;
     *)
-      log "Invalid option: $1"
-      usage
+      echo "Internal error!"
+      exit 1
       ;;
   esac
-  shift
 done
 
 ##############################################################

--- a/caasp-devenv
+++ b/caasp-devenv
@@ -37,6 +37,8 @@ LOCATION=${CAASP_LOCATION:-}
 PARALLELISM=${CAASP_PARALLELISM:-1}
 ENABLE_TILLER=${CAASP_ENABLE_TILLER:-false}
 EXTRA_REPO=${CAASP_EXTRA_REPO:-}
+PLATFORM="${CAASP_PLATFORM:-caasp-kvm}"
+declare -r PLATFORMS=(caasp-kvm caasp-openstack-terraform)
 
 EARLY_DIST_PACKAGES="lsb-release"
 DIST_PACKAGES="jq \
@@ -80,6 +82,7 @@ Usage:
     -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS)
     -u|--update-deployment           Update Terraform deployment (Default: false)
     -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS)
+    --platform                       Platform to deploy CaaSP on (Default: CAASP_PLATTFORM)
     --vanilla                        Do not inject devenv code, use vanilla caasp (Default: false)
     --disable-meltdown-spectre-fixes Disable meltdown and spectre fixes (Default: false)
     --enable-tiller                  Enable Helm Tiller
@@ -148,9 +151,21 @@ clone_needed_github_repos() {
         fi
   done
   popd
-} 
+}
 
-OPTS=$(getopt -o Bbdhi:L:m:P:p:T:uw: --long build,bootstrap,destroy,disable-meltdown-spectre-fixes,enable-tiller,extra-repo:,help,location,parallelism:,plan,proxy:,setup,testinfra:,vanilla -n "$0" -- "$@")
+in_array() {
+    local x item=${1} _found=1
+    shift
+    declare -a local p=(${@})
+    for x in ${p[@]}; do
+        if [[ ${item} == ${x} ]]; then
+            _found=0
+            break
+        fi
+    done
+    return $_found
+}
+
 OPTS=$(getopt -o Bbdhi:L:m:P:p:T:uw: --long build,bootstrap,destroy,disable-meltdown-spectre-fixes,enable-tiller,extra-repo:,help,location,parallelism:,plan,platform:,proxy:,setup,testinfra:,vanilla -n "$0" -- "$@")
 eval set -- "$OPTS"
 
@@ -226,6 +241,13 @@ while true; do
       RUN_PLAN=1
       shift
       ;;
+    --platform)
+      ACTION=1
+      PLATFORM=$2
+      # Check that platform is actually supported
+      ! in_array ${PLATFORM} "${PLATFORMS[@]}" && echo "Unsupported platform: $PLATFORM" && exit 1
+      shift 2
+      ;;
     --setup)
       ACTION=1
       RUN_SETUP=1
@@ -247,15 +269,15 @@ done
 
 ##############################################################
 
-CAASP_KVM_ARGS="-m $MASTERS -w $WORKERS --image $IMAGE"
-[ -n "$PARALLELISM" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --parallelism $PARALLELISM"
-[ -n "$PROXY"       ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --proxy $PROXY"
-[ -n "$LOCATION"    ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --location $LOCATION"
-[ -n "$VANILLA"     ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --vanilla"
-[ -n "$DISABLE_MELTDOWN_SPECTRE" ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --disable-meltdown-spectre-fixes"
-[ -n "$EXTRA_REPO"  ] && CAASP_KVM_ARGS="$CAASP_KVM_ARGS --extra-repo $EXTRA_REPO"
+CAASP_PLATFORM_ARGS="-m $MASTERS -w $WORKERS --image $IMAGE"
+[ -n "$PARALLELISM" ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --parallelism $PARALLELISM"
+[ -n "$PROXY"       ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --proxy $PROXY"
+[ -n "$LOCATION"    ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --location $LOCATION"
+[ -n "$VANILLA"     ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --vanilla"
+[ -n "$DISABLE_MELTDOWN_SPECTRE" ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --disable-meltdown-spectre-fixes"
+[ -n "$EXTRA_REPO"  ] && CAASP_PLATFORM_ARGS="$CAASP_PLATFORM_ARGS --extra-repo $EXTRA_REPO"
 
-export ENVIRONMENT="$DIR/caasp-kvm/environment.json"
+export ENVIRONMENT="$DIR/$PLATFORM/environment.json"
 
 # Core methods
 setup() {
@@ -300,18 +322,18 @@ setup() {
 }
 
 plan() {
-  log "Planning CaaSP KVM Environment"
-  (cd "$DIR/caasp-kvm" && ./caasp-kvm --plan $CAASP_KVM_ARGS )
+  log "Planning CaaSP Environment"
+  (cd "$DIR/$PLATFORM" && ./$PLATFORM --plan $CAASP_PLATFORM_ARGS )
 }
 
 build() {
-  log "Starting CaaSP KVM Environment"
-  (cd "$DIR/caasp-kvm" && ./caasp-kvm --build $CAASP_KVM_ARGS )
+  log "Starting CaaSP Environment"
+  (cd "$DIR/$PLATFORM" && ./$PLATFORM --build $CAASP_PLATFORM_ARGS )
 }
 
 update_deployment() {
-  log "Updating CaaSP KVM Environment"
-  (cd "$DIR/caasp-kvm" && ./caasp-kvm --update-deployment $CAASP_KVM_ARGS )
+  log "Updating CaaSP Environment"
+  (cd "$DIR/$PLATFORM" && ./$PLATFORM --update-deployment $CAASP_PLATFORM_ARGS )
 }
 
 bootstrap() {
@@ -334,7 +356,7 @@ testinfra() {
 
 destroy() {
   log "Destroy CaaSP KVM Environment"
-  (cd "$DIR/caasp-kvm" && ./caasp-kvm --destroy $CAASP_KVM_ARGS)
+  (cd "$DIR/$PLATFORM" && ./$PLATFORM --destroy $CAASP_PLATFORM_ARGS)
 }
 
 [ -n "$ACTION" ] || usage

--- a/caasp-openstack-terraform/caasp-openstack-terraform
+++ b/caasp-openstack-terraform/caasp-openstack-terraform
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+# options
+ACTION=
+RUN_BUILD=
+RUN_DESTROY=
+RUN_UPDATE_DEPLOYMENT=
+RUN_PLAN=
+
+# caasp or kubic
+DIST=${CAASP_DIST:-caasp}
+
+MASTERS=${CAASP_NUM_MASTERS:-1}
+WORKERS=${CAASP_NUM_WORKERS:-2}
+IMAGE=${CAASP_IMAGE:-channel://devel}
+NETWORK=${CAASP_NETWORK:-container-ci}
+PARALLELISM=${CAASP_PARALLELISM:-1}
+CAASP_NAME_PREFIX=${CAASP_NAME_PREFIX:-$(whoami)}
+
+TFVARS_FILE=${CAASP_TFVARS_FILE:-}
+
+EXTRA_REPO=${CAASP_EXTRA_REPO:-}
+
+# the environment file
+ENVIRONMENT=$DIR/environment.json
+
+USAGE=$(cat <<USAGE
+Usage:
+
+  * Building a cluster
+
+    -b|--build                       Run the CaaSP Build Step
+    -m|--masters <INT>               Number of masters to build (Default: CAASP_NUM_MASTERS=$MASTERS)
+    -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
+    -n|--network <STR>               Neutron network for internal communications (Default: CAASP_NETWORK:$NETWORK)
+    -i|--image <STR>                 Image to use (Default: CAASP_IMAGE=$IMAGE)
+
+  * Destroying a cluster
+
+    -d|--destroy                     Run the CaaSP KVM Destroy Step
+
+  * Common options
+
+    -p|--parallelism                 Set terraform parallelism (Default: CAASP_PARALLELISM)
+
+  * Advanced Options
+
+    --openrc <STR>                   openRC file to source
+    --name-prefix <STR>              Name prefix for the terraform resources
+    --plan                           Run the CaaSP KVM Plan Step
+    --tfvars-file <STR>              Path to a specific .tfvars file to use (Default: .)
+
+  * Examples:
+
+  Build a 1 master, 2 worker cluster
+
+  $0 --build -m 1 -w 2
+
+  Build a 1 master, 2 worker cluster using the latest CaaSP image
+
+  $0 --build -m 1 -w 2 --image CaaSP-devel-4.0-Build123
+
+  Destroy a cluster
+
+  $0 --destroy
+
+  Note: If the image is not present on the OpenStack cloud, then the script will upload it for you.
+
+USAGE
+)
+
+# Utility methods
+log()        { (>&2 echo ">>> [caasp-openstack-terraform] $@") ; }
+warn()       { log "WARNING: $@" ; }
+error()      { log "ERROR: $@" ; exit 1 ; }
+check_file() { if [ ! -f $1 ]; then error "File $1 doesn't exist!"; fi }
+usage()      { echo "$USAGE" ; exit 0 ; }
+
+# parse options
+while [[ $# > 0 ]] ; do
+  case $1 in
+    -b|--build)
+      ACTION=1
+      RUN_BUILD=1
+      ;;
+    -m|--masters)
+      MASTERS="$2"
+      shift
+      ;;
+    -n|--network)
+      NETWORK="$2"
+      shift
+      ;;
+    -w|--workers)
+      WORKERS="$2"
+      shift
+      ;;
+    -i|--image)
+      IMAGE="$2"
+      shift
+      ;;
+    -p|--parallelism)
+      PARALLELISM="$2"
+      shift
+      ;;
+    -d|--destroy)
+      ACTION=1
+      RUN_DESTROY=1
+      ;;
+    -u|--update-deployment)
+      ACTION=1
+      RUN_UPDATE_DEPLOYMENT=1
+      ;;
+    --openrc)
+      OPENRC_FILE="$2"
+      shift
+      ;;
+    --name-prefix)
+      CAASP_NAME_PREFIX="$2"
+      shift
+      ;;
+    --plan)
+      ACTION=1
+      RUN_PLAN=1
+      ;;
+    --tfvars-file)
+      TFVARS_FILE="$2"
+      shift
+      ;;
+    --extra-repo)
+      EXTRA_REPO="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      log "Invalid option: $1"
+      usage
+      ;;
+  esac
+  shift
+done
+
+################################################################
+
+TF_ARGS="-parallelism=$PARALLELISM \
+         -var internal_net=$NETWORK \
+         -var masters=$MASTERS \
+         -var workers=$WORKERS"
+
+if [ ! -z "${TFVARS_FILE}" ] ; then
+    TF_ARGS="-var-file=$TFVARS_FILE \
+        ${TF_ARGS}"
+fi
+
+if [ -n "$CAASP_NAME_PREFIX" ] ; then
+    TF_ARGS="$TF_ARGS -var stack_name=$CAASP_NAME_PREFIX"
+    log "Using name prefix for terraform: $CAASP_NAME_PREFIX"
+fi
+
+if [[ ${OPENRC_FILE:-x} != x ]] && [[ -e ${OPENRC_FILE} ]]; then
+    source ${OPENRC_FILE}
+else
+    if [[ ${OS_AUTH_URL:-x} == x ]]; then
+            error "OS_AUTH_URL is not set! Did you forget to source your openrc file?"
+    fi
+fi
+
+check_image() {
+    local image=${1}
+
+    log "Preparing image for ${image}"
+
+    download_image() {
+        local image=${image/channel:\/\//}
+        if ! openstack -q image list --property caasp-channel="${image}" 2>/dev/null; then
+            log "No image was found for channel=${CHANNEL}. A new one will be uploaded..."
+            $DIR../misc/tools/download-image --type openstack channel://${image}
+            $DIR../misc/tools/upload-image-openstack.sh false ${image}
+        fi
+        IMAGE=$(openstack image list -c Name -f value --property caasp-channel="${image}")
+        log "Final image was set to ${IMAGE}"
+    }
+
+    if [[ -n ${image} ]]; then
+        if ! openstack -q image list -c Name -f value --name "${image} 2>/dev/null"; then
+            log "No image named '${image}' was found on glance. Checking properties instead..."
+            download_image
+        fi
+    fi
+
+    TF_ARGS="$TF_ARGS -var image_name=$IMAGE"
+}
+
+build() {
+    log "CaaS Platform Building"
+    check_image ${IMAGE}
+
+    update_deployment
+
+    log "Waiting for Velum to start - this may take a while"
+    PYTHONUNBUFFERED=1 "$DIR/../misc-tools/wait-for-velum" --timeout 30 https://$(jq -r '.dashboardExternalHost' "$ENVIRONMENT")
+
+    log "CaaS Platform Ready for bootstrap"
+}
+
+plan() {
+    log "Planning terraform configuration"
+    terraform plan $TF_ARGS
+}
+
+update_deployment() {
+    log "Applying terraform configuration"
+    terraform init && terraform apply -auto-approve $TF_ARGS
+
+    ./tools/generate-environment
+    $DIR/../misc-tools/generate-ssh-config $ENVIRONMENT
+}
+
+destroy() {
+    log "Destroying terraform configuration"
+    terraform init && \
+        terraform destroy -auto-approve $TF_ARGS && \
+    rm -f "$ENVIRONMENT"
+}
+
+[ -n "$ACTION" ] || usage
+[ -n "$RUN_PLAN" ] && plan
+[ -n "$RUN_BUILD" ] && build
+[ -n "$RUN_UPDATE_DEPLOYMENT" ] && update_deployment
+[ -n "$RUN_DESTROY" ] && destroy
+
+exit 0

--- a/caasp-openstack-terraform/tools/generate-environment
+++ b/caasp-openstack-terraform/tools/generate-environment
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -eu
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+# environment file, provided as the first argument
+ENVIRONMENT=${1:-${ENVIRONMENT:-"$DIR/../environment.json"}}
+
+# ssh key file
+SSH_KEY=${SSH_KEY:-$DIR/../ssh/id_caasp}
+
+# terraform state file
+TF_STATE=${TF_STATE:-$DIR/../terraform.tfstate}
+
+##############################################################
+
+SSH_ARGS="-i $SSH_KEY \
+         -o UserKnownHostsFile=/dev/null \
+         -o StrictHostKeyChecking=no"
+
+command -v jq >/dev/null || {
+    echo "ERROR: jq is not installed - please install jq to generate the environment.json file"
+    exit 1
+}
+
+# make sure the ssh key is readable
+[ -f "$SSH_KEY" ] || { echo "No ssh key found at $SSH_KEY" ; exit 1 ; }
+chmod 600 "$SSH_KEY"
+
+echo "Generating $ENVIRONMENT file"
+
+# Floating IPs are a separate resource so we need to get them first
+floating_ips=$(cat $TF_STATE | \
+    jq ".modules[].resources[] | select(.type==\"openstack_compute_floatingip_associate_v2\") | .primary | .attributes | { floating_ip, id: .instance_id } " | jq -s .)
+
+combined_list=$(cat $TF_STATE | \
+    jq ".modules[].resources[] | select(.type==\"openstack_compute_instance_v2\") | .primary | .attributes" | jq -s .)
+
+# We are going to use floating IP as FQDN because we do not have DNS
+out=$(echo $combined_list $floating_ips | jq -s 'add' | jq "group_by(.id) | .[] | .[0] + .[1] | { fqdn: .name, addresses: { publicIpv4: .floating_ip, privateIpv4: .access_ip_v4 }, role: .name | split(\"-\") | .[1], index: (if (.name | split(\"-\") | .[2]) == null then 0 else .name | split(\"-\") | .[2] end) , status: \"unused\" }"  | jq -s . | jq "{ minions: . }")
+
+for node in $(echo "$out" | jq -r '.minions[] | select(.["minion_id"]? == null) | [.addresses.publicIpv4] | join(" ")'); do
+    # The node may not have fully booted yet
+    x=0
+    while [ $x -le 10 ]; do
+        nc -z $node 22 && break
+        sleep 10
+        x=$(( $x + 1 ))
+    done
+    machine_id=$(ssh root@$node $SSH_ARGS cat /etc/machine-id)
+    out=$(echo "$out" | jq ".minions | map(if (.addresses.publicIpv4 == \"$node\") then . + {\"minionID\": \"$machine_id\"} else . end) | {minions: .}")
+done
+
+masters=$(echo "$out" | jq -r '[.minions[] | select(.role=="master")] | length')
+
+out=$(echo "$out" | jq " . + {dashboardHost: .minions[] | select(.role==\"admin\") | .addresses.publicIpv4, dashboardExternalHost: .minions[] | select(.role==\"admin\") | .addresses.publicIpv4, kubernetesExternalHost: .minions[] | select(.role==\"master\") | .addresses.publicIpv4}")
+out=$(echo "$out" | jq " . + {sshKey: \"$SSH_KEY\", sshUser: \"root\"}")
+
+echo "$out" | tee "$ENVIRONMENT"

--- a/jenkins-jobs/jobs.yaml
+++ b/jenkins-jobs/jobs.yaml
@@ -82,6 +82,25 @@
           suppress-automatic-scm-triggering: true
 
 - job:
+    name: caasp-nightly-openstack-terraform
+    project-type: multibranch
+    periodic-folder-trigger: 1h
+    number-to-keep: 30
+    days-to-keep: 30
+    scriptPath: jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack-terraform
+    scm:
+      - github:
+          '': 'ca19dcff-4869-4dd2-888d-e07238d293fb'
+          repo: 'automation'
+          repo-owner: 'kubic-project'
+          credentials-id: 'github-token-caaspjenkins'
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: false
+          discover-pr-origin: false
+          filter-head-regex: ^(master|release\-\d\.\d)$
+          suppress-automatic-scm-triggering: true
+
+- job:
     name: caasp-nightly-e2e
     project-type: multibranch
     periodic-folder-trigger: 1h

--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack-terraform
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-openstack-terraform
@@ -1,0 +1,45 @@
+env.BRANCH_NAME = "openstack-terraform"
+def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubic
+env.BRANCH_NAME = "master"
+// This pipeline runs daily tests on VMware
+
+// Configure the build properties
+// Configure the build properties
+    buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
+    disableConcurrentBuilds(),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
+    parameters([
+        string(name: 'MASTER_COUNT', defaultValue: '1', description: 'Number of Master Nodes'),
+        string(name: 'WORKER_COUNT', defaultValue: '2', description: 'Number of Worker Nodes'),
+        booleanParam(name: 'ENVIRONMENT_DESTROY', defaultValue: true, description: 'Destroy env once done?')
+    ])
+])
+
+def openstackTypeOptions = kubicLib.OpenstackTypeOptions.new();
+
+coreKubicProjectPeriodic(
+    environmentType: 'openstack',
+    environmentTypeOptions: openstackTypeOptions,
+    environmentDestroy: env.ENVIRONMENT_DESTROY.toBoolean(),
+    masterCount: env.MASTER_COUNT.toInteger(),
+    workerCount: env.WORKER_COUNT.toInteger(),
+) {
+    // empty preBootstrapBody
+} {
+    // Run through the upgrade orchestration
+    upgradeEnvironmentStage1(
+        environment: environment,
+        fakeUpdatesAvailable: true
+    )
+
+    upgradeEnvironmentStage2(
+        environment: environment
+    )
+
+    // Run the Core Project Tests again
+    coreKubicProjectNodeTests(
+        environment: environment
+    )
+
+    return environment
+}

--- a/misc-tools/netdata/install
+++ b/misc-tools/netdata/install
@@ -24,7 +24,7 @@ def main():
     sshkey = env['sshKey']
     target = [m for m in env["minions"] if m["role"] == args.target]
     for t in target:
-        ipaddr = t["addresses"]["privateIpv4"]
+        ipaddr = t["addresses"]["publicIpv4"]
         basecmd = "/usr/bin/ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -i {} {}@{} ".format(sshkey, sshuser, ipaddr)
         cmd = basecmd + "curl -Ss https://my-netdata.io/kickstart-static64.sh -o netdata_installer.sh"
         runcmd(cmd)

--- a/misc-tools/parallelssh/tool.py
+++ b/misc-tools/parallelssh/tool.py
@@ -89,7 +89,7 @@ def extract_target_ipaddrs(args, env):
     # Extract target host ipaddrs
     role = args.target_roles.rstrip('s')
     target_ipaddrs = [
-        b["addresses"]["privateIpv4"] for b in env["minions"]
+        b["addresses"]["publicIpv4"] for b in env["minions"]
         if role in ("all", b["role"])
     ]
     if not target_ipaddrs:

--- a/misc-tools/upload-image-openstack.sh
+++ b/misc-tools/upload-image-openstack.sh
@@ -10,7 +10,7 @@ IMAGE_BUILD=$(echo $IMAGE_FILENAME | sed -n 's/.*\(Build.*\).qcow2/\1/p')
 IMAGE_VERSION=$(echo $IMAGE_FILENAME | sed -n 's/.*CaaS-Platform-\(.*\)-\(for\|CaaSP\).*-OpenStack-Cloud.*/\1/p')
 IMAGE_NAME="CaaSP-${CHANNEL}-${IMAGE_VERSION}-${IMAGE_BUILD}"
 
-source $OPENRC
+[[ -e $OPENRC ]] && source $OPENRC
 echo "[+] Checking if we already have this image: $IMAGE_NAME"
 
 if [[ $(openstack image list -c ID -f value --property caasp-version="${IMAGE_VERSION}" --property caasp-channel="${CHANNEL}" --property caasp-build="${IMAGE_BUILD}") != "" ]]; then

--- a/velum-bootstrap/velum-interactions
+++ b/velum-bootstrap/velum-interactions
@@ -21,7 +21,7 @@ RUN_ADD_REGISTRY=false
 REMOTE_REGISTRY_NAME=${REMOTE_REGISTRY_NAME:-'test-remote-registry'}
 REMOTE_REGISTRY_URL=${REMOTE_REGISTRY_URL:-'http://test-remote-registry.com'}
 
-ENVIRONMENT=${CAASP_ENVIRONMENT:-$DIR/../caasp-kvm/environment.json}
+[[ ${ENVIRONMENT:-x} == x ]] && ENVIRONMENT=${CAASP_ENVIRONMENT:-$DIR/../caasp-kvm/environment.json}
 
 USAGE=$(cat <<USAGE
 Usage:


### PR DESCRIPTION
This PR introduces caasp-openstack-terraform script which plugs into caasp-devenv to create development environments in OpenStack. The script alone can also be used by the CI to run nightly jobs. Finally, a new OpenStack pipeline was added.