### PR TITLE
caasp-devenv: Add explicit exit code

### DIFF
--- a/caasp-devenv
+++ b/caasp-devenv
@@ -374,3 +374,5 @@ destroy() {
 [ -n "$RUN_BOOTSTRAP" ] && bootstrap
 [ -n "$RUN_TESTINFRA" ] && testinfra
 [ -n "$RUN_DESTROY" ] && destroy
+
+exit 0


### PR DESCRIPTION
The script ends with multiple evaluation statements and in case the
last one is false then the script exists with non-zero exit code. As
such we need to be explicit and exit with '0' at the end.

Fixes: bsc#1125050