### PR TITLE
Add support for cinder volumes to workers in openstack terraform

### DIFF
--- a/caasp-openstack-terraform/caasp-openstack-terraform
+++ b/caasp-openstack-terraform/caasp-openstack-terraform
@@ -21,6 +21,9 @@ NETWORK=${CAASP_NETWORK:-container-ci}
 PARALLELISM=${CAASP_PARALLELISM:-1}
 CAASP_NAME_PREFIX=${CAASP_NAME_PREFIX:-$(whoami)}
 
+WORKERS_VOL_ENABLED=${CAASP_WORKERS_VOL_ENABLED:-0}
+WORKERS_VOL_SIZE=${CAASP_WORKERS_VOL_SIZE:-5}
+
 TFVARS_FILE=${CAASP_TFVARS_FILE:-}
 
 EXTRA_REPO=${CAASP_EXTRA_REPO:-}
@@ -38,6 +41,11 @@ Usage:
     -w|--workers <INT>               Number of workers to build (Default: CAASP_NUM_WORKERS=$WORKERS)
     -n|--network <STR>               Neutron network for internal communications (Default: CAASP_NETWORK:$NETWORK)
     -i|--image <STR>                 Image to use (Default: CAASP_IMAGE=$IMAGE)
+
+  * Customizing a cluster
+
+    --workers-vol-enabled            Add one volume per worker node (Default: 0 (disabled))
+    --workers-vol-size               Define the size in gb of the volume (Default: 5)
 
   * Destroying a cluster
 
@@ -99,6 +107,14 @@ while [[ $# > 0 ]] ; do
       WORKERS="$2"
       shift
       ;;
+    --workers-vol-enabled)
+      WORKERS_VOL_ENABLED="$2"
+      shift
+      ;;
+    --workers-vol-size)
+      WORKERS_VOL_SIZE="$2"
+      shift
+      ;;
     -i|--image)
       IMAGE="$2"
       shift
@@ -155,6 +171,12 @@ TF_ARGS="-parallelism=$PARALLELISM \
 
 if [ ! -z "${TFVARS_FILE}" ] ; then
     TF_ARGS="-var-file=$TFVARS_FILE \
+        ${TF_ARGS}"
+fi
+
+if [[ "${WORKERS_VOL_ENABLED}" != "0" ]]; then
+    TF_ARGS="-var workers_vol_enabled=${WORKERS_VOL_ENABLED} \
+        -var workers_vol_size=${WORKERS_VOL_SIZE} \
         ${TF_ARGS}"
 fi
 

--- a/caasp-openstack-terraform/terraform.tfvars
+++ b/caasp-openstack-terraform/terraform.tfvars
@@ -2,11 +2,13 @@ image_name = "SUSE-CaaS-Platform-3.0-for-OpenStack-Cloud.x86_64-3.0.0-GM.qcow2"
 internal_net = "CHANGE_ME-net"
 external_net = "floating"
 admin_size = "m1.large"
-master_size = "m1.large"
+master_size = "m1.medium"
 masters = 1
-worker_size = "m1.large"
+worker_size = "m1.medium"
 workers = 2
+workers_vol_enabled = 0
+workers_vol_size = 5
 
 dnsdomain = "testing.qa.caasp.suse.net"
-dnsentry = "0"
+dnsentry = 0
 stack_name = "CHANGE_ME"


### PR DESCRIPTION
## What does this PR change?
- What was wrong with the existing code?
- How does this PR fixes it?

This allows us to attach volume to worker nodes so we can test storage solutions on top of CaaSP.

This also change the "default" flavors for masters and workers from `m1.large` to `m1.medium`. 4gb and 2vcpu is what we use on other platforms, this is enough.

Signed-off-by: Ludovic Cavajani <lcavajani@suse.com>
