### PR TITLE
caasp-openstack-terraform: Always use the latest image

### DIFF
--- a/caasp-openstack-terraform/caasp-openstack-terraform
+++ b/caasp-openstack-terraform/caasp-openstack-terraform
@@ -183,7 +183,7 @@ check_image() {
             $DIR../misc/tools/download-image --type openstack channel://${image}
             $DIR../misc/tools/upload-image-openstack.sh false ${image}
         fi
-        IMAGE=$(openstack image list -c Name -f value --property caasp-channel="${image}")
+        IMAGE=$(openstack image list -c Name -f value --property caasp-channel="${image}" --sort name:desc | head -n 1)
         log "Final image was set to ${IMAGE}"
     }
 


### PR DESCRIPTION
If we have more than one image available for a specific version,
channel, etc when we need to sort them based on Name and fetch the top
one. The way we construct and upload our images to glance guarantees
that the build name is part of the name so the top one will always be
the most recent one