### PR TITLE
jenkins-pipelines: upgrade: Run the upgrade job once a day

### DIFF
--- a/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
+++ b/jenkins-pipelines/Jenkinsfile.kubic-nightly-upgrade
@@ -4,8 +4,7 @@ def kubicLib = library("kubic-jenkins-library@${env.BRANCH_NAME}").com.suse.kubi
 properties([
     buildDiscarder(logRotator(numToKeepStr: '31', daysToKeepStr: '31')),
     disableConcurrentBuilds(),
-    // Run every two hours
-    pipelineTriggers([cron('H H/2 * * *')]),
+    pipelineTriggers([cron('H H(3-5) * * *')]),
 ])
 
 def kvmTypeOptions = kubicLib.CaaspKvmTypeOptions.new();


### PR DESCRIPTION
There is no good reason why we should run the job every two hours.
We should treat it like the rest of the dailies and run it once a day.

(cherry picked from commit 46bb85e6a0cde90428d044767fe51af9e9c19a1c)