### PR TITLE
misc-tools: upload-image-openstack: Fix wrong variable name

### DIFF
--- a/misc-tools/upload-image-openstack.sh
+++ b/misc-tools/upload-image-openstack.sh
@@ -22,7 +22,7 @@ if [[ $(openstack image list -c ID -f value --property caasp-version="${IMAGE_VE
         echo "[+] Deleting previous SUSE CaaSP qcow2 VM image for {version=$IMAGE_VERSION, channel=$CHANNEL}"
         for image in $(openstack image list -c Name -f value --property caasp-version="${IMAGE_VERSION}" --property caasp-channel="${CHANNEL}"); do
             [[ $image == $IMAGE_NAME ]] && continue
-            openstack image delete $images
+            openstack image delete $image
         done
     else
         echo "Failed to upload new image ${IMAGE_NAME}"


### PR DESCRIPTION
The correct variable for the iteration is 'image' so fix it. This fixes
the following problem in the CI

[...]
[+] Deleting previous SUSE CaaSP qcow2 VM image for {version=4.0,channel=devel}
./upload-image-openstack.sh: line 25: images: unbound variable

(cherry picked from commit 7c487f7282151575b22e00d3ccfe5be67f1772fb)